### PR TITLE
Bytter ut bruk av infoFraPunsj

### DIFF
--- a/src/app/containers/pleiepenger/SoknadKvittering/SoknadKvittering.tsx
+++ b/src/app/containers/pleiepenger/SoknadKvittering/SoknadKvittering.tsx
@@ -96,6 +96,7 @@ export const genererIkkeSkalHaFerie = (perioder: IPSBSoknadKvitteringLovbestemtF
 
 const SoknadKvittering: React.FunctionComponent<IOwnProps> = ({intl, response}) => {
         const ytelse = response.ytelse;
+        const journalposter = response.journalposter;
         const skalHaferieListe = genererSkalHaFerie(ytelse.lovbestemtFerie.perioder);
         const skalIkkeHaFerieListe = genererIkkeSkalHaFerie(ytelse.lovbestemtFerie.perioder);
         const visSoknadsperiode = sjekkPropertyEksistererOgIkkeErNull('søknadsperiode', ytelse) && ytelse.søknadsperiode.length > 0;
@@ -293,16 +294,16 @@ const SoknadKvittering: React.FunctionComponent<IOwnProps> = ({intl, response}) 
                     />
                 </div>}
 
-                {'infoFraPunsj' in ytelse && <div>
+                {!!journalposter && journalposter.length > 0 && <div>
                   <h3>{intlHelper(intl, 'skjema.soknadskvittering.tilleggsopplysninger')}</h3>
                   <hr className={classNames('linje')}/>
                   <p>
                     <b>{intlHelper(intl, 'skjema.medisinskeopplysninger') + ': '}</b>
-                      {`${ytelse.infoFraPunsj?.inneholderMedisinskeOpplysninger !== null && ytelse.infoFraPunsj?.inneholderMedisinskeOpplysninger ? 'Ja' : 'Nei'}`}
+                      {`${typeof journalposter[0].inneholderMedisinskeOpplysninger !== 'undefined' && journalposter[0].inneholderMedisinskeOpplysninger ? 'Ja' : 'Nei'}`}
                   </p>
                   <p>
                     <b>{intlHelper(intl, 'skjema.opplysningerikkepunsjet') + ': '}</b>
-                      {`${ytelse.infoFraPunsj?.søknadenInneholderInfomasjonSomIkkeKanPunsjes !== null && ytelse.infoFraPunsj?.søknadenInneholderInfomasjonSomIkkeKanPunsjes ? 'Ja' : 'Nei'}`}
+                      {`${typeof journalposter[0].inneholderInfomasjonSomIkkeKanPunsjes !== 'undefined' && journalposter[0].inneholderInfomasjonSomIkkeKanPunsjes ? 'Ja' : 'Nei'}`}
                   </p>
                 </div>
                 }

--- a/src/app/models/types/PSBSoknadKvittering.ts
+++ b/src/app/models/types/PSBSoknadKvittering.ts
@@ -73,9 +73,15 @@ export interface IPSBSoknadKvitteringFrilanser {
     jobberFortsattSomFrilans: boolean;
 }
 
+export interface IPSBSoknadKvitteringJournalpost {
+    inneholderInfomasjonSomIkkeKanPunsjes?: boolean;
+    inneholderMedisinskeOpplysninger?: boolean;
+    journalpostId: string;
+}
 
 export interface IPSBSoknadKvittering {
     mottattDato: string;
+    journalposter: IPSBSoknadKvitteringJournalpost[];
     ytelse: {
         type: string;
         barn: {
@@ -83,10 +89,6 @@ export interface IPSBSoknadKvittering {
             fødselsdato: string | null;
         },
         søknadsperiode: string[];
-        infoFraPunsj?: {
-            søknadenInneholderInfomasjonSomIkkeKanPunsjes: boolean;
-            inneholderMedisinskeOpplysninger: boolean
-        };
         bosteder: { perioder: IPSBSoknadKvitteringBosteder };
         utenlandsopphold: { perioder: IPSBSoknadKvitteringUtenlandsopphold; }
         beredskap: { perioder: IPSBSoknadKvitteringBeredskapNattevak };

--- a/src/test/containers/pleiepenger/PSBPunchForm.spec.tsx
+++ b/src/test/containers/pleiepenger/PSBPunchForm.spec.tsx
@@ -69,6 +69,7 @@ const initialSoknad: IPSBSoknad = {
 }
 
 const validertSoknad: IPSBSoknadKvittering = {
+    journalposter: [],
     mottattDato: '',
     ytelse: {
         type: '',

--- a/src/test/containers/pleiepenger/SoknadKvittering.spec.tsx
+++ b/src/test/containers/pleiepenger/SoknadKvittering.spec.tsx
@@ -145,6 +145,7 @@ const fullResponse: IPSBSoknadKvittering = {
 };
 
 const minimalResponse: IPSBSoknadKvittering = {
+    journalposter: [],
     mottattDato: "2020-10-12T12:53:00.000Z",
     ytelse: {
         type: "PLEIEPENGER_SYKT_BARN",

--- a/src/test/containers/pleiepenger/SoknadKvittering.spec.tsx
+++ b/src/test/containers/pleiepenger/SoknadKvittering.spec.tsx
@@ -14,6 +14,11 @@ jest.mock('app/utils/intlUtils');
 jest.mock('app/utils/pathUtils');
 
 const fullResponse: IPSBSoknadKvittering = {
+    journalposter: [{
+        journalpostId: '',
+        inneholderInfomasjonSomIkkeKanPunsjes: false,
+        inneholderMedisinskeOpplysninger: false
+    }],
     mottattDato: "2020-10-12T12:53:00.000Z",
     ytelse: {
         type: "PLEIEPENGER_SYKT_BARN",
@@ -55,10 +60,6 @@ const fullResponse: IPSBSoknadKvittering = {
                 organisasjonsnummer: "231232321323",
                 virksomhetNavn: "Navn As"
             }]
-        },
-        infoFraPunsj: {
-            søknadenInneholderInfomasjonSomIkkeKanPunsjes: false,
-            inneholderMedisinskeOpplysninger: false
         },
         bosteder: {
             perioder: {


### PR DESCRIPTION
infoFraPunsj brukes ikke lengre i retur fra validering. Informasjonen er tillknyttet hver journalpost og finnes därför i lista over journalpost. I nuläget er det ikke situationer där olike journalposter har ulik informasjon for variablarna endret men på sikt kan det kommer. Krever dock mer tillrättaläggning i olika system.