### PR TITLE
Oppgrader baseimage fra nodejs18-debian11 til nodejs18-debian12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs18-debian11:nonroot
+FROM gcr.io/distroless/nodejs18-debian12:nonroot
 
 ENV TZ="Europe/Oslo"
 ENV NODE_ENV=production


### PR DESCRIPTION
Fikser forhåpentligvis sårbarheter fra gammelt image