### PR TITLE
Datovelger bugfix

### DIFF
--- a/src/app/components/formikInput/DatoInputFormikNew.tsx
+++ b/src/app/components/formikInput/DatoInputFormikNew.tsx
@@ -15,7 +15,6 @@ interface OwnProps extends Omit<DatePickerProps, 'value' | 'onChange' | 'disable
 const DatoInputFormikNew = ({ label, name, handleBlur, hideLabel, ...props }: OwnProps) => {
     const [field, meta, helper] = useField(name);
     const { values } = useFormikContext<FormikValues>();
-
     return (
         <NewDateInput
             label={label}
@@ -31,6 +30,7 @@ const DatoInputFormikNew = ({ label, name, handleBlur, hideLabel, ...props }: Ow
                     handleBlur(() => helper.setTouched(true, true), set({ ...values }, name, selectedDate));
                 } else {
                     helper.setValue(selectedDate);
+                    helper.setTouched(true, true);
                     field.onBlur(selectedDate);
                 }
             }}

--- a/src/app/components/skjema/NewDateInput/NewDateInput.tsx
+++ b/src/app/components/skjema/NewDateInput/NewDateInput.tsx
@@ -60,6 +60,7 @@ const NewDateInput: React.FC<Props> = ({
     const onDateChange = (date?: Date) => {
         if (!date) {
             onChange('');
+            return;
         }
         const isoDateString = date ? dateToISODateString(date) : '';
         if (isoDateString && isoDateString !== value) {

--- a/src/app/components/skjema/NewDateInput/NewDateInput.tsx
+++ b/src/app/components/skjema/NewDateInput/NewDateInput.tsx
@@ -40,7 +40,7 @@ const NewDateInput: React.FC<Props> = ({
     id,
     inputDisabled,
     disabled,
-    noValidateTomtFelt,
+    noValidateTomtFelt = true,
     inputRef,
     locale,
     onBlur,
@@ -58,6 +58,9 @@ const NewDateInput: React.FC<Props> = ({
     const toDateDefault = new Date().setFullYear(new Date().getFullYear() + 5);
 
     const onDateChange = (date?: Date) => {
+        if (!date) {
+            onChange('');
+        }
         const isoDateString = date ? dateToISODateString(date) : '';
         if (isoDateString && isoDateString !== value) {
             onChange(isoDateString);


### PR DESCRIPTION
### **Behov / Bakgrunn**
- Bør sette touched når man går ut av feltet.
- I onDateChange vil date være undefined dersom det ikke er fylt inn en gyldig dato. Sånn som det er nå vil gyldige datoer bli hengende igjen i formstate fordi verdi ikke oppdateres med mindre vi har en gyldig dato, men det er ikke synlig for bruker.