### PR TITLE
Fix: Løs radioknapp-synkronisering i Utenlandsopphold-komponenten PP sykt barn

### DIFF
--- a/src/app/søknader/pleiepenger/containers/Utenlandsopphold/Utenlandsopphold.tsx
+++ b/src/app/søknader/pleiepenger/containers/Utenlandsopphold/Utenlandsopphold.tsx
@@ -84,11 +84,8 @@ export const Utenlandsopphold: React.FunctionComponent<IUtenlandsoppholdProps> =
         periods = [],
     } = props;
     const { intl, component, editSoknad, editSoknadState, kanHaFlere, initialValues } = props;
-    const [visInnlagtPerioder, setVisInnlagtPerioder] = useState(
-        periods.some((periode) => periode.innleggelsesperioder && periode.innleggelsesperioder.length > 0)
-            ? jaValue
-            : '',
-    );
+    // Bruker objekt for å lagre state per element
+    const [visInnlagtPerioder, setVisInnlagtPerioder] = useState<{ [key: number]: string }>({});
     const editInfo: (
         index: number,
         periodeinfo: Partial<Periodeinfo<IUtenlandsOpphold>>,
@@ -135,6 +132,19 @@ export const Utenlandsopphold: React.FunctionComponent<IUtenlandsoppholdProps> =
                     return 'null';
                 }
                 return innleggelsesperioder[0].årsak;
+            }
+            return '';
+        };
+
+        // Henter verdi for radioknapp fra state
+        const getVisInnlagtPerioder = () => {
+            // Hvis det finnes innleggelsesperioder, er "Ja" valgt
+            if (periods[periodeindeks].innleggelsesperioder && periods[periodeindeks].innleggelsesperioder.length > 0) {
+                return jaValue;
+            }
+            // Hvis det finnes lagret state for dette elementet, bruk den
+            if (visInnlagtPerioder[periodeindeks]) {
+                return visInnlagtPerioder[periodeindeks];
             }
             return '';
         };
@@ -202,14 +212,19 @@ export const Utenlandsopphold: React.FunctionComponent<IUtenlandsoppholdProps> =
                                     value: 'nei',
                                 },
                             ]}
-                            name={`arbeidsgivertype_${1}`}
+                            name={`innleggelse_${periodeindeks}`}
                             legend={`Er, eller skal, barnet være innlagt i helseinstitusjon i ${countries.getName(
                                 land,
                                 'nb',
                             )}?`}
                             onChange={(event) => {
                                 const { value } = event.target as HTMLInputElement;
-                                setVisInnlagtPerioder(value);
+                                // Oppdaterer state for dette elementet
+                                setVisInnlagtPerioder((prev) => ({
+                                    ...prev,
+                                    [periodeindeks]: value,
+                                }));
+
                                 if (value !== jaValue) {
                                     const editedInfo = () =>
                                         editInfo(periodeindeks, {
@@ -219,12 +234,12 @@ export const Utenlandsopphold: React.FunctionComponent<IUtenlandsoppholdProps> =
                                     editSoknadState(editedInfo());
                                 }
                             }}
-                            checked={visInnlagtPerioder}
+                            checked={getVisInnlagtPerioder()}
                         />
                     </div>
                 )}
 
-                {visInnlagtPerioder === jaValue && (
+                {getVisInnlagtPerioder() === jaValue && (
                     <div className="mt-6">
                         <Heading level="3" size="small">
                             <FormattedMessage id={'skjema.utenlandsopphold.barnInnlagtPerioder.tittel'} />


### PR DESCRIPTION
### **Behov / Bakgrunn**

I Utenlandsopphold-komponenten oppstod det et problem hvor radioknappene "Er, eller skal, barnet være innlagt i helseinstitusjon i ..." ikke fungerte korrekt når det ble lagt til flere Utenlandsopphold-elementer. Når brukeren endret "Ja/Nei"-valget i ett element, påvirket dette alle andre elementer i listen. Dette skjedde fordi alle radioknappene delte samme globale state `visInnlagtPerioder`, noe som førte til at endringer i ett element automatisk påvirket alle andre.

### **Løsning**

Implementerte objekt-basert state management hvor hvert Utenlandsopphold-element får sitt eget unike state:

- Erstattet global `visInnlagtPerioder` state med `useState<{[key: number]: string}>`
- Bruker `periodeindeks` som nøkkel for å sikre unikt state per element
- Oppdaterte `onChange`-handleren til å oppdatere state kun for det spesifikke elementet
- La til unike `name`-attributter ved å bruke `innleggelse_${periodeindeks}`
- Opprettet `getVisInnlagtPerioder()`-funksjon som leser state for spesifikt element

### **Andre endringer**

- Fjernet unødvendig `as any` type casting
