### PR TITLE
TSFF-1984: datepicker fom-tom

### DIFF
--- a/src/app/components/arbeidsforholdFormik/ArbeidsforholdPanel.tsx
+++ b/src/app/components/arbeidsforholdFormik/ArbeidsforholdPanel.tsx
@@ -90,7 +90,7 @@ const ArbeidsforholdPanel = ({ isOpen, onPanelClick, eksisterendePerioder }: Arb
         });
 
     const frilanserperioder = () => (
-        <>
+        <div>
             <DatoInputFormikNew
                 className="frilanser-startdato"
                 name="opptjeningAktivitet.frilanser.startdato"
@@ -108,14 +108,22 @@ const ArbeidsforholdPanel = ({ isOpen, onPanelClick, eksisterendePerioder }: Arb
                     />
                 )}
             </Field>
-
             <VerticalSpacer sixteenPx />
-
             {!values.opptjeningAktivitet.frilanser?.jobberFortsattSomFrilans && (
                 <DatoInputFormikNew
                     className="frilanser-sluttdato"
                     name="opptjeningAktivitet.frilanser.sluttdato"
                     label={intlHelper(intl, 'skjema.frilanserdato.slutt')}
+                    fromDate={
+                        values.opptjeningAktivitet.frilanser?.startdato
+                            ? new Date(values.opptjeningAktivitet.frilanser.startdato)
+                            : undefined
+                    }
+                    defaultMonth={
+                        values.opptjeningAktivitet.frilanser?.startdato
+                            ? new Date(values.opptjeningAktivitet.frilanser.startdato)
+                            : undefined
+                    }
                 />
             )}
 
@@ -143,7 +151,7 @@ const ArbeidsforholdPanel = ({ isOpen, onPanelClick, eksisterendePerioder }: Arb
                     </Field>
                 </>
             )}
-        </>
+        </div>
     );
 
     const selvstendigperioder = () => {
@@ -282,6 +290,16 @@ const ArbeidsforholdPanel = ({ isOpen, onPanelClick, eksisterendePerioder }: Arb
                         className="tom"
                         label={intlHelper(intl, 'skjema.arbeid.sn.sluttdato')}
                         name="opptjeningAktivitet.selvstendigNaeringsdrivende.info.periode.tom"
+                        fromDate={
+                            opptjeningAktivitet.selvstendigNaeringsdrivende?.info?.periode?.fom
+                                ? new Date(opptjeningAktivitet.selvstendigNaeringsdrivende.info.periode.fom)
+                                : undefined
+                        }
+                        defaultMonth={
+                            opptjeningAktivitet.selvstendigNaeringsdrivende?.info?.periode?.fom
+                                ? new Date(opptjeningAktivitet.selvstendigNaeringsdrivende.info.periode.fom)
+                                : undefined
+                        }
                     />
                 </div>
 

--- a/src/app/components/period-input/PeriodInput.tsx
+++ b/src/app/components/period-input/PeriodInput.tsx
@@ -97,6 +97,8 @@ export const PeriodInput: React.FunctionComponent<IPeriodInputProps> = (props: I
                         // limitations={limitations}
                         label={intlHelper(intl, 'skjema.perioder.tom')}
                         dataTestId="tom"
+                        fromDate={periode.fom ? new Date(periode.fom) : undefined}
+                        defaultMonth={periode.fom ? new Date(periode.fom) : undefined}
                     />
                 </div>
             </HStack>

--- a/src/app/components/period-input/PeriodInput.tsx
+++ b/src/app/components/period-input/PeriodInput.tsx
@@ -67,6 +67,10 @@ export const PeriodInput: React.FunctionComponent<IPeriodInputProps> = (props: I
         }
     };
 
+    // Vi sjekker om fom er en gyldig dato
+    const isValidFromDate = periode.fom && new Date(periode.fom).toString() !== 'Invalid Date';
+    const fromDateValue = isValidFromDate ? new Date(periode.fom!) : undefined;
+
     return (
         <Fieldset error={errorMessage} className={className} legend={undefined}>
             <HStack wrap gap="4" justify="center">
@@ -97,8 +101,8 @@ export const PeriodInput: React.FunctionComponent<IPeriodInputProps> = (props: I
                         // limitations={limitations}
                         label={intlHelper(intl, 'skjema.perioder.tom')}
                         dataTestId="tom"
-                        fromDate={periode.fom ? new Date(periode.fom) : undefined}
-                        defaultMonth={periode.fom ? new Date(periode.fom) : undefined}
+                        fromDate={fromDateValue}
+                        defaultMonth={fromDateValue}
                     />
                 </div>
             </HStack>

--- a/src/app/søknader/opplæringspenger/containers/Bosteder.tsx
+++ b/src/app/søknader/opplæringspenger/containers/Bosteder.tsx
@@ -67,6 +67,16 @@ const Bosteder: React.FC = () => {
                                         <DatoInputFormikNew
                                             label="Til og med"
                                             name={`bosteder[${index}].periode.tom`}
+                                            fromDate={
+                                                values.bosteder[index].periode.fom
+                                                    ? new Date(values.bosteder[index].periode.fom)
+                                                    : undefined
+                                            }
+                                            defaultMonth={
+                                                values.bosteder[index].periode.fom
+                                                    ? new Date(values.bosteder[index].periode.fom)
+                                                    : undefined
+                                            }
                                         />
 
                                         {array.length > 1 && (

--- a/src/app/søknader/opplæringspenger/containers/Utenlandsopphold.tsx
+++ b/src/app/søknader/opplæringspenger/containers/Utenlandsopphold.tsx
@@ -23,7 +23,20 @@ const Utenlandsopphold: React.FC<Props> = ({ arrayHelpers, fieldArrayIndex }: Pr
             <div className="flex gap-2 justify-between">
                 <div className="flex gap-2">
                     <DatoInputFormikNew label="Fra og med" name={`utenlandsopphold[${fieldArrayIndex}].periode.fom`} />
-                    <DatoInputFormikNew label="Til og med" name={`utenlandsopphold[${fieldArrayIndex}].periode.tom`} />
+                    <DatoInputFormikNew 
+                        label="Til og med" 
+                        name={`utenlandsopphold[${fieldArrayIndex}].periode.tom`}
+                        fromDate={
+                            values.utenlandsopphold[fieldArrayIndex].periode.fom
+                                ? new Date(values.utenlandsopphold[fieldArrayIndex].periode.fom)
+                                : undefined
+                        }
+                        defaultMonth={
+                            values.utenlandsopphold[fieldArrayIndex].periode.fom
+                                ? new Date(values.utenlandsopphold[fieldArrayIndex].periode.fom)
+                                : undefined
+                        }
+                    />
                 </div>
                 {values.utenlandsopphold.length > 1 && (
                     <div className="block content-center">

--- a/src/app/søknader/opplæringspenger/containers/UtenlandsoppholdContainer.tsx
+++ b/src/app/søknader/opplæringspenger/containers/UtenlandsoppholdContainer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { FieldArray, useFormikContext } from 'formik';
-import { PersonPlusIcon } from '@navikt/aksel-icons';
+import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { Box, Button, Heading } from '@navikt/ds-react';
 import { FormattedMessage } from 'react-intl';
 
@@ -64,7 +64,7 @@ const UtenlandsoppholdContainer = () => {
                                 variant="tertiary"
                                 size="small"
                                 onClick={() => arrayHelpers.push(utenlandsoppholdInitialValue)}
-                                icon={<PersonPlusIcon />}
+                                icon={<PlusCircleIcon />}
                             >
                                 <FormattedMessage id="skjema.utenlandsopphold.utenlandsoppholdContainer.leggTil.btn" />
                             </Button>


### PR DESCRIPTION
Endringer i OLP og PeroidInput felleskomponent.

Datepicker åpner for tom-dato  i samme måned som er oppgitt i fom, dersom noe er oppgitt. 
Datoer som er før fom-dato er grået ut i datepicker for tom. Man kan fortsatt omgå det ved å skrive fritekst dato, men stoppes av validering i backend. 

Legger til sjekk på om fom er en gyldig dato i tilfelle uferdig dato eller random string, så vi ikke plutselig sender inn "Invalid date" og får error

