### PR TITLE
Legg til Faro custom events for manuell journalpostflyt

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Kort logg over merkbare repo-endringer og oppsettendringer.
 
+### Faro analytics skips SDK dedupe for manual punsj events (2026-04-20)
+
+- Lar nå manuelle `Faro`-events for `Opprett journalpost` og `PSB`-submit gå med `skipDedupe`, slik at gjentatte men legitime analytics-hendelser ikke lettere faller bort i frontend-SDK-et.
+- Holder custom analytics-sporet smalt, men gjør det tryggere å sammenligne flere manuelle journalpost-innsendinger over tid i Grafana.
+
 ### Faro initialization waits for nais config (2026-04-20)
 
 - Venter nå eksplisitt på at `nais.js` skal lastes ferdig før `initializeFaro(...)` kjøres i frontend.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Kort logg over merkbare repo-endringer og oppsettendringer.
 
+### Faro initialization waits for nais config (2026-04-20)
+
+- Venter nå eksplisitt på at `nais.js` skal lastes ferdig før `initializeFaro(...)` kjøres i frontend.
+- Gjør frontend-observability mer stabil ved direkte inngang i appen, der `window.nais` tidligere kunne være utilgjengelig akkurat når appen startet.
+
 ### Faro custom events for manual journalpost flow (2026-04-13)
 
 - La til en liten `Faro` helper for manuelle frontend-events, som første steg mot produktmåling i stedet for bare teknisk observability.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Kort logg over merkbare repo-endringer og oppsettendringer.
 
+### Faro custom events for manual journalpost flow (2026-04-13)
+
+- La til en liten `Faro` helper for manuelle frontend-events, som første steg mot produktmåling i stedet for bare teknisk observability.
+- Sender nå et første trygt custom `Faro` event når brukeren åpner `Opprett journalpost`, slik at vi kan verifisere at custom `Faro` events er synlige i dev og kan brukes i egne Grafana-panels senere.
+- La til en smal enhetstest for helperen, inkludert guard når `telemetryCollectorURL` mangler og verifisering av forventet payload for det første eventet.
+
 ### Package maintenance follow up (2026-04-10)
 
 - Lot `axios@1.15.0` vente foreløpig, fordi repoets `npmMinimalAgeGate: 7d` i `.yarnrc.yml` blokkerer den versjonen frem til minst 2026-04-15, og vi ønsket ikke å omgå den policyen i samme pass.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@ Kort logg over merkbare repo-endringer og oppsettendringer.
 
 - La til en liten `Faro` helper for manuelle frontend-events, som første steg mot produktmåling i stedet for bare teknisk observability.
 - Sender nå et første trygt custom `Faro` event når brukeren åpner `Opprett journalpost`, slik at vi kan verifisere at custom `Faro` events er synlige i dev og kan brukes i egne Grafana-panels senere.
+- Lagrer nå hvilke journalposter som blir opprettet manuelt i sesjonen, slik at videre punsjflyt kan kobles tilbake til `Opprett journalpost` uten å sende persondata eller interne payload-verdier til analytics.
+- Sender nå `Faro` submit-events for `PSB` basert på kvitteringen fra backend, men med bevisst smal taksonomi. Foreløpig måles bare `arbeidstid`, `trekk_av_periode`, `periode` og samlet `annet`, slik at vi kan teste hypotesen uten å sende unødvendig detaljgrad til analytics.
 - La til en smal enhetstest for helperen, inkludert guard når `telemetryCollectorURL` mangler og verifisering av forventet payload for det første eventet.
 
 ### Package maintenance follow up (2026-04-10)

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -4,6 +4,7 @@ declare global {
     interface Window {
         envVariables: EnvVariables;
         appSettings?: Record<string, string | undefined>;
+        __naisReady?: Promise<unknown>;
         nais?: {
             telemetryCollectorURL: string;
             app: any;

--- a/src/@types/styles.d.ts
+++ b/src/@types/styles.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -39,12 +39,9 @@ import '@navikt/ds-css';
 import './styles/globals.css';
 
 const environment = window.location.hostname;
-type WindowWithNaisReady = Window & {
-    __naisReady?: Promise<unknown>;
-};
 
 const waitForNaisConfig = async (): Promise<void> => {
-    const naisReady = (window as WindowWithNaisReady).__naisReady;
+    const naisReady = window.__naisReady;
 
     if (naisReady) {
         await naisReady;

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -39,9 +39,22 @@ import '@navikt/ds-css';
 import './styles/globals.css';
 
 const environment = window.location.hostname;
+type WindowWithNaisReady = Window & {
+    __naisReady?: Promise<unknown>;
+};
+
+const waitForNaisConfig = async (): Promise<void> => {
+    const naisReady = (window as WindowWithNaisReady).__naisReady;
+
+    if (naisReady) {
+        await naisReady;
+    }
+};
 
 const prepare = async () => {
     if (window.location.hostname.includes('nav.no')) {
+        await waitForNaisConfig();
+
         if (window.nais?.app && window.nais?.telemetryCollectorURL) {
             initializeFaro({
                 url: window.nais?.telemetryCollectorURL,

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -6,7 +6,7 @@
         <script type="module">
             // Dynamically import nais.js. Workaround til vi kan importere nais.js direkte i app.tsx via relative path når vi bytter til vite
             // https://docs.nais.io/explanation/observability/frontend/?h=faro#tracing-opentelemetry
-            import('/dist/js/nais.js')
+            window.__naisReady = import('/dist/js/nais.js')
                 .then((naisModule) => {
                     const faroConfig = naisModule.default;
                     window.nais = faroConfig;

--- a/src/app/opprett-journalpost/OpprettJournalpost.tsx
+++ b/src/app/opprett-journalpost/OpprettJournalpost.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ChangeEvent } from 'react';
+import React, { useEffect, useState, ChangeEvent } from 'react';
 
 import { useForm } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -12,6 +12,7 @@ import { finnVisningsnavnForSakstype, post } from 'app/utils';
 import { IOpprettJournalpostForm, OpprettJournalpostFormKeys } from './types';
 import { getTypedFormComponents } from 'app/components/form/getTypedFormComponents';
 import { useValidationRules } from './useValidationRules';
+import { trackManualJournalpostFlowStarted } from 'app/utils/faroEvents';
 
 import './opprettJournalpost.css';
 
@@ -37,6 +38,10 @@ const OpprettJournalpost: React.FC = () => {
     const [fetchFagsakError, setFetchFagsakError] = useState(false);
 
     const { søkerIdentitetsnummerValidator, fagsakIdValidator, tittelValidator, notatValidator } = useValidationRules();
+
+    useEffect(() => {
+        trackManualJournalpostFlowStarted();
+    }, []);
 
     const methods = useForm<IOpprettJournalpostForm>({
         defaultValues: defaultValues,

--- a/src/app/opprett-journalpost/OpprettJournalpost.tsx
+++ b/src/app/opprett-journalpost/OpprettJournalpost.tsx
@@ -9,10 +9,10 @@ import { finnFagsaker } from 'app/api/api';
 import { ApiPath } from 'app/apiConfig';
 import Fagsak from 'app/types/Fagsak';
 import { finnVisningsnavnForSakstype, post } from 'app/utils';
-import { IOpprettJournalpostForm, OpprettJournalpostFormKeys } from './types';
+import { IOpprettJournalpostForm, IOpprettJournalpostResponse, OpprettJournalpostFormKeys } from './types';
 import { getTypedFormComponents } from 'app/components/form/getTypedFormComponents';
 import { useValidationRules } from './useValidationRules';
-import { trackManualJournalpostFlowStarted } from 'app/utils/faroEvents';
+import { setManualJournalpostFlowSource, trackManualJournalpostFlowStarted } from 'app/utils/faroEvents';
 
 import './opprettJournalpost.css';
 
@@ -104,9 +104,10 @@ const OpprettJournalpost: React.FC = () => {
     const onSubmit = async (values: IOpprettJournalpostForm) => {
         setOpprettJpError('');
         return new Promise<void>((resolve) => {
-            post(ApiPath.OPPRETT_NOTAT, undefined, undefined, values, (response, data) => {
+            post(ApiPath.OPPRETT_NOTAT, undefined, undefined, values, (response, data: IOpprettJournalpostResponse) => {
                 if (response.status === 201) {
                     setOpprettetJournalpostId(data.journalpostId);
+                    setManualJournalpostFlowSource(data.journalpostId);
                     resolve();
                 } else {
                     reset(values, { keepValues: true, keepErrors: true, keepDirty: true, keepTouched: true });

--- a/src/app/søknader/pleiepenger/containers/PSBPunchForm.tsx
+++ b/src/app/søknader/pleiepenger/containers/PSBPunchForm.tsx
@@ -83,6 +83,7 @@ import {
     periodKeyFromPeriode,
     resolvePeriodInputPart,
 } from '../utils/errorAnchorUtils';
+import { trackPsbSubmitFromJournalpost } from 'app/utils/faroEvents';
 
 export interface IPunchFormComponentProps {
     journalpostid: string;
@@ -246,15 +247,21 @@ export class PunchFormComponent extends React.Component<IPunchFormProps, IPunchF
         }
     }
 
-    componentDidUpdate() {
-        const { soknad } = this.props.punchFormState;
+    componentDidUpdate(prevProps: IPunchFormProps) {
+        const { punchFormState, journalpostid } = this.props;
+        const { soknad, innsentSoknad, isComplete } = punchFormState;
+
+        if (!prevProps.punchFormState.isComplete && isComplete && innsentSoknad) {
+            trackPsbSubmitFromJournalpost(journalpostid, innsentSoknad);
+        }
+
         // this.props.updateJournalposter(this.state.soknad.journalposter);
         if (soknad && !this.state.isFetched) {
             this.setState({
-                soknad: new PSBSoknad(this.props.punchFormState.soknad as IPSBSoknad),
+                soknad: new PSBSoknad(punchFormState.soknad as IPSBSoknad),
                 isFetched: true,
-                iTilsynsordning: !!this.props.punchFormState.soknad?.tilsynsordning?.perioder?.length,
-                aapnePaneler: this.getÅpnePanelerVedStart(this.props.punchFormState.soknad as IPSBSoknad),
+                iTilsynsordning: !!punchFormState.soknad?.tilsynsordning?.perioder?.length,
+                aapnePaneler: this.getÅpnePanelerVedStart(punchFormState.soknad as IPSBSoknad),
             });
             if (!soknad.barn || !soknad.barn.norskIdent || soknad.barn.norskIdent === '') {
                 this.updateSoknad({ barn: { norskIdent: this.props.identState.pleietrengendeId || '' } });

--- a/src/app/søknader/pleiepenger/containers/PSBPunchForm.tsx
+++ b/src/app/søknader/pleiepenger/containers/PSBPunchForm.tsx
@@ -83,7 +83,7 @@ import {
     periodKeyFromPeriode,
     resolvePeriodInputPart,
 } from '../utils/errorAnchorUtils';
-import { trackPsbSubmitFromJournalpost } from 'app/utils/faroEvents';
+import { trackPsbStartedFromJournalpost, trackPsbSubmitFromJournalpost } from 'app/utils/faroEvents';
 
 export interface IPunchFormComponentProps {
     journalpostid: string;
@@ -224,6 +224,7 @@ export class PunchFormComponent extends React.Component<IPunchFormProps, IPunchF
     componentDidMount() {
         const { id } = this.props;
         this.props.getSoknad(id);
+        trackPsbStartedFromJournalpost(this.props.journalpostid);
         this.setState((prevState) => {
             const updatedFeilmeldingStier = new Set(prevState.feilmeldingStier); // Create a copy of the previous state
 

--- a/src/app/utils/faroEvents.ts
+++ b/src/app/utils/faroEvents.ts
@@ -1,0 +1,24 @@
+import { EventAttributes, faro } from '@grafana/faro-web-sdk';
+import { ROUTES } from 'app/constants/routes';
+
+export const MANUAL_JOURNALPOST_FLOW_STARTED_EVENT = 'manual_journalpost_flow_started';
+
+export const pushFaroEvent = (name: string, attributes?: EventAttributes): boolean => {
+    if (typeof window === 'undefined' || !window.nais?.telemetryCollectorURL) {
+        return false;
+    }
+
+    try {
+        faro.api.pushEvent(name, attributes);
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+export const trackManualJournalpostFlowStarted = (): boolean =>
+    pushFaroEvent(MANUAL_JOURNALPOST_FLOW_STARTED_EVENT, {
+        source: 'opprett_journalpost',
+        route: ROUTES.OPPRETT_JOURNALPOST,
+        phase: 'page_opened',
+    });

--- a/src/app/utils/faroEvents.ts
+++ b/src/app/utils/faroEvents.ts
@@ -1,7 +1,134 @@
 import { EventAttributes, faro } from '@grafana/faro-web-sdk';
 import { ROUTES } from 'app/constants/routes';
+import { IPSBSoknadKvittering } from 'app/models/types/PSBSoknadKvittering';
 
 export const MANUAL_JOURNALPOST_FLOW_STARTED_EVENT = 'manual_journalpost_flow_started';
+export const PUNSJ_SUBMIT_SNAPSHOT_EVENT = 'punsj_submit_snapshot';
+export const PUNSJ_SUBMIT_FIELD_GROUP_EVENT = 'punsj_submit_field_group';
+
+const OPPRETT_JOURNALPOST_SOURCE = 'opprett_journalpost';
+const UNKNOWN_SOURCE = 'unknown';
+const MANUAL_JOURNALPOST_SOURCE_SESSION_KEY = 'manualJournalpostSourceIds';
+
+export const PSB_FIELD_GROUPS = {
+    ARBEIDSTID: 'arbeidstid',
+    TREKK_AV_PERIODE: 'trekk_av_periode',
+    PERIODE: 'periode',
+    ANNET: 'annet',
+} as const;
+
+type PunsjSource = typeof OPPRETT_JOURNALPOST_SOURCE | typeof UNKNOWN_SOURCE;
+type PsbFieldGroup = (typeof PSB_FIELD_GROUPS)[keyof typeof PSB_FIELD_GROUPS];
+
+const PSB_FIELD_GROUP_ORDER: PsbFieldGroup[] = [
+    PSB_FIELD_GROUPS.ARBEIDSTID,
+    PSB_FIELD_GROUPS.TREKK_AV_PERIODE,
+    PSB_FIELD_GROUPS.PERIODE,
+    PSB_FIELD_GROUPS.ANNET,
+];
+
+const getSessionStorage = (): Storage | undefined => {
+    if (typeof window === 'undefined') {
+        return undefined;
+    }
+
+    try {
+        return window.sessionStorage;
+    } catch {
+        return undefined;
+    }
+};
+
+const normalizeJournalpostId = (journalpostId: string): string => journalpostId.trim();
+
+const readManualJournalpostSourceIds = (): string[] => {
+    const storage = getSessionStorage();
+
+    if (!storage) {
+        return [];
+    }
+
+    try {
+        const rawValue = storage.getItem(MANUAL_JOURNALPOST_SOURCE_SESSION_KEY);
+
+        if (!rawValue) {
+            return [];
+        }
+
+        const parsedValue = JSON.parse(rawValue);
+
+        if (!Array.isArray(parsedValue)) {
+            return [];
+        }
+
+        return parsedValue.filter(
+            (value): value is string => typeof value === 'string' && normalizeJournalpostId(value).length > 0,
+        );
+    } catch {
+        return [];
+    }
+};
+
+const writeManualJournalpostSourceIds = (journalpostIds: string[]): boolean => {
+    const storage = getSessionStorage();
+
+    if (!storage) {
+        return false;
+    }
+
+    try {
+        if (journalpostIds.length === 0) {
+            storage.removeItem(MANUAL_JOURNALPOST_SOURCE_SESSION_KEY);
+        } else {
+            storage.setItem(MANUAL_JOURNALPOST_SOURCE_SESSION_KEY, JSON.stringify(journalpostIds));
+        }
+
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+const hasRecordEntries = (value?: Record<string, unknown> | null): boolean => !!value && Object.keys(value).length > 0;
+
+const hasArbeidstidPerioder = (innsentSoknad: IPSBSoknadKvittering): boolean => {
+    const { arbeidstid } = innsentSoknad.ytelse;
+
+    const arbeidstakerHarArbeidstid = arbeidstid.arbeidstakerList.some((arbeidstaker) =>
+        hasRecordEntries(arbeidstaker.arbeidstidInfo?.perioder),
+    );
+
+    return (
+        arbeidstakerHarArbeidstid ||
+        hasRecordEntries(arbeidstid.frilanserArbeidstidInfo?.perioder) ||
+        hasRecordEntries(arbeidstid.selvstendigNæringsdrivendeArbeidstidInfo?.perioder)
+    );
+};
+
+const hasOmsorgsinformasjon = (innsentSoknad: IPSBSoknadKvittering): boolean => {
+    const { omsorg } = innsentSoknad.ytelse;
+
+    return [omsorg.relasjonTilBarnet, omsorg.beskrivelseAvOmsorgsrollen].some((value) =>
+        typeof value === 'string' ? value.trim().length > 0 : false,
+    );
+};
+
+const hasAnnetPsbInnhold = (innsentSoknad: IPSBSoknadKvittering): boolean => {
+    const { ytelse } = innsentSoknad;
+
+    return (
+        hasRecordEntries(ytelse.tilsynsordning.perioder) ||
+        hasRecordEntries(ytelse.beredskap.perioder) ||
+        hasRecordEntries(ytelse.nattevåk.perioder) ||
+        hasRecordEntries(ytelse.lovbestemtFerie.perioder) ||
+        hasRecordEntries(ytelse.utenlandsopphold.perioder) ||
+        hasRecordEntries(ytelse.bosteder.perioder) ||
+        hasRecordEntries(ytelse.uttak.perioder) ||
+        hasOmsorgsinformasjon(innsentSoknad) ||
+        !!ytelse.opptjeningAktivitet.frilanser ||
+        (ytelse.opptjeningAktivitet.selvstendigNæringsdrivende?.length || 0) > 0
+    );
+};
 
 export const pushFaroEvent = (name: string, attributes?: EventAttributes): boolean => {
     if (typeof window === 'undefined' || !window.nais?.telemetryCollectorURL) {
@@ -18,7 +145,101 @@ export const pushFaroEvent = (name: string, attributes?: EventAttributes): boole
 
 export const trackManualJournalpostFlowStarted = (): boolean =>
     pushFaroEvent(MANUAL_JOURNALPOST_FLOW_STARTED_EVENT, {
-        source: 'opprett_journalpost',
+        source: OPPRETT_JOURNALPOST_SOURCE,
         route: ROUTES.OPPRETT_JOURNALPOST,
         phase: 'page_opened',
     });
+
+export const setManualJournalpostFlowSource = (journalpostId: string): boolean => {
+    const normalizedJournalpostId = normalizeJournalpostId(journalpostId);
+
+    if (!normalizedJournalpostId) {
+        return false;
+    }
+
+    const journalpostIds = new Set(readManualJournalpostSourceIds());
+    journalpostIds.add(normalizedJournalpostId);
+
+    return writeManualJournalpostSourceIds(Array.from(journalpostIds));
+};
+
+export const getPunsjSourceForJournalpost = (journalpostId: string): PunsjSource => {
+    const normalizedJournalpostId = normalizeJournalpostId(journalpostId);
+
+    if (!normalizedJournalpostId) {
+        return UNKNOWN_SOURCE;
+    }
+
+    return readManualJournalpostSourceIds().includes(normalizedJournalpostId)
+        ? OPPRETT_JOURNALPOST_SOURCE
+        : UNKNOWN_SOURCE;
+};
+
+export const clearManualJournalpostFlowSource = (journalpostId: string): boolean => {
+    const normalizedJournalpostId = normalizeJournalpostId(journalpostId);
+
+    if (!normalizedJournalpostId) {
+        return false;
+    }
+
+    return writeManualJournalpostSourceIds(
+        readManualJournalpostSourceIds().filter((storedJournalpostId) => storedJournalpostId !== normalizedJournalpostId),
+    );
+};
+
+export const getPsbSubmittedFieldGroups = (innsentSoknad: IPSBSoknadKvittering): PsbFieldGroup[] => {
+    const fieldGroups = new Set<PsbFieldGroup>();
+    const { ytelse } = innsentSoknad;
+
+    if (hasArbeidstidPerioder(innsentSoknad)) {
+        fieldGroups.add(PSB_FIELD_GROUPS.ARBEIDSTID);
+    }
+
+    if (ytelse.trekkKravPerioder.length > 0) {
+        fieldGroups.add(PSB_FIELD_GROUPS.TREKK_AV_PERIODE);
+    }
+
+    if (ytelse.søknadsperiode.length > 0) {
+        fieldGroups.add(PSB_FIELD_GROUPS.PERIODE);
+    }
+
+    if (hasAnnetPsbInnhold(innsentSoknad)) {
+        fieldGroups.add(PSB_FIELD_GROUPS.ANNET);
+    }
+
+    return PSB_FIELD_GROUP_ORDER.filter((fieldGroup) => fieldGroups.has(fieldGroup));
+};
+
+export const trackPsbSubmitFromJournalpost = (
+    journalpostId: string,
+    innsentSoknad: IPSBSoknadKvittering,
+): PsbFieldGroup[] => {
+    const source = getPunsjSourceForJournalpost(journalpostId);
+
+    if (source === UNKNOWN_SOURCE) {
+        return [];
+    }
+
+    const fieldGroups = getPsbSubmittedFieldGroups(innsentSoknad);
+    const sharedAttributes = {
+        source,
+        sakstype: 'PSB',
+    };
+
+    pushFaroEvent(PUNSJ_SUBMIT_SNAPSHOT_EVENT, {
+        ...sharedAttributes,
+        used_field_groups: fieldGroups.join(',') || 'none',
+        used_field_group_count: String(fieldGroups.length),
+    });
+
+    fieldGroups.forEach((fieldGroup) => {
+        pushFaroEvent(PUNSJ_SUBMIT_FIELD_GROUP_EVENT, {
+            ...sharedAttributes,
+            field_group: fieldGroup,
+        });
+    });
+
+    clearManualJournalpostFlowSource(journalpostId);
+
+    return fieldGroups;
+};

--- a/src/app/utils/faroEvents.ts
+++ b/src/app/utils/faroEvents.ts
@@ -3,6 +3,7 @@ import { ROUTES } from 'app/constants/routes';
 import { IPSBSoknadKvittering } from 'app/models/types/PSBSoknadKvittering';
 
 export const MANUAL_JOURNALPOST_FLOW_STARTED_EVENT = 'manual_journalpost_flow_started';
+export const PUNSJ_STARTED_EVENT = 'punsj_started';
 export const PUNSJ_SUBMIT_SNAPSHOT_EVENT = 'punsj_submit_snapshot';
 export const PUNSJ_SUBMIT_FIELD_GROUP_EVENT = 'punsj_submit_field_group';
 
@@ -208,6 +209,19 @@ export const getPsbSubmittedFieldGroups = (innsentSoknad: IPSBSoknadKvittering):
     }
 
     return PSB_FIELD_GROUP_ORDER.filter((fieldGroup) => fieldGroups.has(fieldGroup));
+};
+
+export const trackPsbStartedFromJournalpost = (journalpostId: string): boolean => {
+    const source = getPunsjSourceForJournalpost(journalpostId);
+
+    if (source === UNKNOWN_SOURCE) {
+        return false;
+    }
+
+    return pushFaroEvent(PUNSJ_STARTED_EVENT, {
+        source,
+        sakstype: 'PSB',
+    });
 };
 
 export const trackPsbSubmitFromJournalpost = (

--- a/src/app/utils/faroEvents.ts
+++ b/src/app/utils/faroEvents.ts
@@ -65,9 +65,19 @@ const readManualJournalpostSourceIds = (): string[] => {
             return [];
         }
 
-        return parsedValue.filter(
-            (value): value is string => typeof value === 'string' && normalizeJournalpostId(value).length > 0,
-        );
+        return parsedValue.reduce<string[]>((journalpostIds, value) => {
+            if (typeof value !== 'string') {
+                return journalpostIds;
+            }
+
+            const normalizedValue = normalizeJournalpostId(value);
+
+            if (normalizedValue.length > 0) {
+                journalpostIds.push(normalizedValue);
+            }
+
+            return journalpostIds;
+        }, []);
     } catch {
         return [];
     }

--- a/src/app/utils/faroEvents.ts
+++ b/src/app/utils/faroEvents.ts
@@ -20,6 +20,9 @@ export const PSB_FIELD_GROUPS = {
 
 type PunsjSource = typeof OPPRETT_JOURNALPOST_SOURCE | typeof UNKNOWN_SOURCE;
 type PsbFieldGroup = (typeof PSB_FIELD_GROUPS)[keyof typeof PSB_FIELD_GROUPS];
+type FaroEventOptions = {
+    skipDedupe?: boolean;
+};
 
 const PSB_FIELD_GROUP_ORDER: PsbFieldGroup[] = [
     PSB_FIELD_GROUPS.ARBEIDSTID,
@@ -131,13 +134,13 @@ const hasAnnetPsbInnhold = (innsentSoknad: IPSBSoknadKvittering): boolean => {
     );
 };
 
-export const pushFaroEvent = (name: string, attributes?: EventAttributes): boolean => {
+export const pushFaroEvent = (name: string, attributes?: EventAttributes, options?: FaroEventOptions): boolean => {
     if (typeof window === 'undefined' || !window.nais?.telemetryCollectorURL) {
         return false;
     }
 
     try {
-        faro.api.pushEvent(name, attributes);
+        faro.api.pushEvent(name, attributes, undefined, options);
         return true;
     } catch {
         return false;
@@ -149,7 +152,7 @@ export const trackManualJournalpostFlowStarted = (): boolean =>
         source: OPPRETT_JOURNALPOST_SOURCE,
         route: ROUTES.OPPRETT_JOURNALPOST,
         phase: 'page_opened',
-    });
+    }, { skipDedupe: true });
 
 export const setManualJournalpostFlowSource = (journalpostId: string): boolean => {
     const normalizedJournalpostId = normalizeJournalpostId(journalpostId);
@@ -221,7 +224,7 @@ export const trackPsbStartedFromJournalpost = (journalpostId: string): boolean =
     return pushFaroEvent(PUNSJ_STARTED_EVENT, {
         source,
         sakstype: 'PSB',
-    });
+    }, { skipDedupe: true });
 };
 
 export const trackPsbSubmitFromJournalpost = (
@@ -244,13 +247,13 @@ export const trackPsbSubmitFromJournalpost = (
         ...sharedAttributes,
         used_field_groups: fieldGroups.join(',') || 'none',
         used_field_group_count: String(fieldGroups.length),
-    });
+    }, { skipDedupe: true });
 
     fieldGroups.forEach((fieldGroup) => {
         pushFaroEvent(PUNSJ_SUBMIT_FIELD_GROUP_EVENT, {
             ...sharedAttributes,
             field_group: fieldGroup,
-        });
+        }, { skipDedupe: true });
     });
 
     clearManualJournalpostFlowSource(journalpostId);

--- a/src/test/utils/faroEvents.spec.ts
+++ b/src/test/utils/faroEvents.spec.ts
@@ -115,6 +115,18 @@ describe('faroEvents', () => {
         expect(pushEventMock).not.toHaveBeenCalled();
     });
 
+    it('Skal videresende Faro-event options til SDK-et', () => {
+        window.nais = {
+            telemetryCollectorURL: 'https://collector.example/collect',
+            app: { name: 'k9-punsj-frontend', version: 'test' },
+        };
+
+        const result = pushFaroEvent('test_event', { source: 'test' }, { skipDedupe: true });
+
+        expect(result).toBeTruthy();
+        expect(pushEventMock).toHaveBeenCalledWith('test_event', { source: 'test' }, undefined, { skipDedupe: true });
+    });
+
     it('Skal sende custom Faro-event for manuelt opprettet journalpost med trygge attributter', () => {
         window.nais = {
             telemetryCollectorURL: 'https://collector.example/collect',
@@ -128,7 +140,7 @@ describe('faroEvents', () => {
             source: 'opprett_journalpost',
             route: '/opprett-journalpost',
             phase: 'page_opened',
-        });
+        }, undefined, { skipDedupe: true });
     });
 
     it('Skal lagre og rydde manuelt opprettet journalpost som kilde for senere punsjflyt', () => {
@@ -164,7 +176,7 @@ describe('faroEvents', () => {
         expect(pushEventMock).toHaveBeenCalledWith(PUNSJ_STARTED_EVENT, {
             source: 'opprett_journalpost',
             sakstype: 'PSB',
-        });
+        }, undefined, { skipDedupe: true });
         expect(getPunsjSourceForJournalpost(journalpostId)).toBe('opprett_journalpost');
     });
 
@@ -184,13 +196,13 @@ describe('faroEvents', () => {
             sakstype: 'PSB',
             used_field_groups: fieldGroups.join(','),
             used_field_group_count: String(fieldGroups.length),
-        });
+        }, undefined, { skipDedupe: true });
         expect(pushEventMock).toHaveBeenCalledTimes(1 + fieldGroups.length);
         expect(pushEventMock).toHaveBeenCalledWith(PUNSJ_SUBMIT_FIELD_GROUP_EVENT, {
             source: 'opprett_journalpost',
             sakstype: 'PSB',
             field_group: PSB_FIELD_GROUPS.ARBEIDSTID,
-        });
+        }, undefined, { skipDedupe: true });
         expect(getPunsjSourceForJournalpost(journalpostId)).toBe('unknown');
     });
 

--- a/src/test/utils/faroEvents.spec.ts
+++ b/src/test/utils/faroEvents.spec.ts
@@ -2,6 +2,7 @@ import { faro } from '@grafana/faro-web-sdk';
 import {
     PUNSJ_SUBMIT_FIELD_GROUP_EVENT,
     PUNSJ_SUBMIT_SNAPSHOT_EVENT,
+    PUNSJ_STARTED_EVENT,
     PSB_FIELD_GROUPS,
     MANUAL_JOURNALPOST_FLOW_STARTED_EVENT,
     clearManualJournalpostFlowSource,
@@ -10,6 +11,7 @@ import {
     pushFaroEvent,
     setManualJournalpostFlowSource,
     trackManualJournalpostFlowStarted,
+    trackPsbStartedFromJournalpost,
     trackPsbSubmitFromJournalpost,
 } from '../../app/utils/faroEvents';
 import { IPSBSoknadKvittering } from '../../app/models/types/PSBSoknadKvittering';
@@ -146,6 +148,24 @@ describe('faroEvents', () => {
             PSB_FIELD_GROUPS.PERIODE,
             PSB_FIELD_GROUPS.ANNET,
         ]);
+    });
+
+    it('Skal sende PSB start-event for manuell journalpostflyt', () => {
+        window.nais = {
+            telemetryCollectorURL: 'https://collector.example/collect',
+            app: { name: 'k9-punsj-frontend', version: 'test' },
+        };
+
+        setManualJournalpostFlowSource(journalpostId);
+
+        const result = trackPsbStartedFromJournalpost(journalpostId);
+
+        expect(result).toBeTruthy();
+        expect(pushEventMock).toHaveBeenCalledWith(PUNSJ_STARTED_EVENT, {
+            source: 'opprett_journalpost',
+            sakstype: 'PSB',
+        });
+        expect(getPunsjSourceForJournalpost(journalpostId)).toBe('opprett_journalpost');
     });
 
     it('Skal sende PSB submit snapshot og feltgruppe-events for manuell journalpostflyt', () => {

--- a/src/test/utils/faroEvents.spec.ts
+++ b/src/test/utils/faroEvents.spec.ts
@@ -99,7 +99,7 @@ describe('faroEvents', () => {
             },
             trekkKravPerioder: ['2026-04-13/2026-04-14'],
         },
-        begrunnelseForInnsending: { tekst: 'test' },
+        begrunnelseForInnsending: { tekst: '' },
     };
 
     beforeEach(() => {
@@ -151,6 +151,14 @@ describe('faroEvents', () => {
 
         expect(clearManualJournalpostFlowSource(journalpostId)).toBeTruthy();
         expect(getPunsjSourceForJournalpost(journalpostId)).toBe('unknown');
+    });
+
+    it('Skal lese journalpostIder fra sessionStorage med trimmet format', () => {
+        window.sessionStorage.setItem('manualJournalpostSourceIds', JSON.stringify(['  jp-123  ']));
+
+        expect(getPunsjSourceForJournalpost(journalpostId)).toBe('opprett_journalpost');
+        expect(clearManualJournalpostFlowSource(journalpostId)).toBeTruthy();
+        expect(window.sessionStorage.getItem('manualJournalpostSourceIds')).toBeNull();
     });
 
     it('Skal mappe PSB-kvittering til forventede feltgrupper', () => {

--- a/src/test/utils/faroEvents.spec.ts
+++ b/src/test/utils/faroEvents.spec.ts
@@ -1,9 +1,18 @@
 import { faro } from '@grafana/faro-web-sdk';
 import {
+    PUNSJ_SUBMIT_FIELD_GROUP_EVENT,
+    PUNSJ_SUBMIT_SNAPSHOT_EVENT,
+    PSB_FIELD_GROUPS,
     MANUAL_JOURNALPOST_FLOW_STARTED_EVENT,
+    clearManualJournalpostFlowSource,
+    getPsbSubmittedFieldGroups,
+    getPunsjSourceForJournalpost,
     pushFaroEvent,
+    setManualJournalpostFlowSource,
     trackManualJournalpostFlowStarted,
+    trackPsbSubmitFromJournalpost,
 } from '../../app/utils/faroEvents';
+import { IPSBSoknadKvittering } from '../../app/models/types/PSBSoknadKvittering';
 
 jest.mock('@grafana/faro-web-sdk', () => ({
     faro: {
@@ -15,10 +24,86 @@ jest.mock('@grafana/faro-web-sdk', () => ({
 
 describe('faroEvents', () => {
     const pushEventMock = faro.api.pushEvent as jest.Mock;
+    const journalpostId = 'jp-123';
+    const psbKvittering: IPSBSoknadKvittering = {
+        journalposter: [],
+        mottattDato: '2026-04-17T10:00:00.000Z',
+        ytelse: {
+            type: 'PSB',
+            barn: {
+                norskIdentitetsnummer: '12345678910',
+                fødselsdato: null,
+            },
+            søknadsperiode: ['2026-04-01/2026-04-10'],
+            bosteder: {
+                perioder: {
+                    '2026-04-01/2026-04-03': { land: 'SWE' },
+                },
+            },
+            utenlandsopphold: {
+                perioder: {
+                    '2026-04-04/2026-04-05': { land: 'DNK' },
+                },
+            },
+            beredskap: {
+                perioder: {
+                    '2026-04-06/2026-04-07': { tilleggsinformasjon: 'beredskap' },
+                },
+            },
+            nattevåk: { perioder: {} },
+            tilsynsordning: {
+                perioder: {
+                    '2026-04-08/2026-04-09': { etablertTilsynTimerPerDag: 'PT5H' },
+                },
+            },
+            lovbestemtFerie: {
+                perioder: {
+                    '2026-04-10/2026-04-10': { skalHaFerie: 'true' },
+                },
+            },
+            arbeidstid: {
+                arbeidstakerList: [
+                    {
+                        norskIdentitetsnummer: null,
+                        organisasjonsnummer: '123456789',
+                        arbeidstidInfo: {
+                            perioder: {
+                                '2026-04-01/2026-04-02': {
+                                    jobberNormaltTimerPerDag: 'PT7H30M',
+                                    faktiskArbeidTimerPerDag: 'PT4H',
+                                },
+                            },
+                        },
+                    },
+                ],
+                frilanserArbeidstidInfo: null,
+                selvstendigNæringsdrivendeArbeidstidInfo: null,
+            },
+            uttak: {
+                perioder: {
+                    '2026-04-11/2026-04-12': { timerPleieAvBarnetPerDag: 'PT6H' },
+                },
+            },
+            omsorg: {
+                relasjonTilBarnet: 'mor',
+                beskrivelseAvOmsorgsrollen: null,
+            },
+            opptjeningAktivitet: {
+                frilanser: {
+                    startdato: '2026-01-01',
+                    sluttdato: null,
+                    jobberFortsattSomFrilans: true,
+                },
+            },
+            trekkKravPerioder: ['2026-04-13/2026-04-14'],
+        },
+        begrunnelseForInnsending: { tekst: 'test' },
+    };
 
     beforeEach(() => {
         pushEventMock.mockClear();
         delete window.nais;
+        window.sessionStorage.clear();
     });
 
     it('Skal ikke sende event når collector url ikke er tilgjengelig', () => {
@@ -42,5 +127,57 @@ describe('faroEvents', () => {
             route: '/opprett-journalpost',
             phase: 'page_opened',
         });
+    });
+
+    it('Skal lagre og rydde manuelt opprettet journalpost som kilde for senere punsjflyt', () => {
+        expect(getPunsjSourceForJournalpost(journalpostId)).toBe('unknown');
+
+        expect(setManualJournalpostFlowSource(journalpostId)).toBeTruthy();
+        expect(getPunsjSourceForJournalpost(journalpostId)).toBe('opprett_journalpost');
+
+        expect(clearManualJournalpostFlowSource(journalpostId)).toBeTruthy();
+        expect(getPunsjSourceForJournalpost(journalpostId)).toBe('unknown');
+    });
+
+    it('Skal mappe PSB-kvittering til forventede feltgrupper', () => {
+        expect(getPsbSubmittedFieldGroups(psbKvittering)).toEqual([
+            PSB_FIELD_GROUPS.ARBEIDSTID,
+            PSB_FIELD_GROUPS.TREKK_AV_PERIODE,
+            PSB_FIELD_GROUPS.PERIODE,
+            PSB_FIELD_GROUPS.ANNET,
+        ]);
+    });
+
+    it('Skal sende PSB submit snapshot og feltgruppe-events for manuell journalpostflyt', () => {
+        window.nais = {
+            telemetryCollectorURL: 'https://collector.example/collect',
+            app: { name: 'k9-punsj-frontend', version: 'test' },
+        };
+
+        setManualJournalpostFlowSource(journalpostId);
+
+        const fieldGroups = trackPsbSubmitFromJournalpost(journalpostId, psbKvittering);
+
+        expect(fieldGroups).toEqual(getPsbSubmittedFieldGroups(psbKvittering));
+        expect(pushEventMock).toHaveBeenNthCalledWith(1, PUNSJ_SUBMIT_SNAPSHOT_EVENT, {
+            source: 'opprett_journalpost',
+            sakstype: 'PSB',
+            used_field_groups: fieldGroups.join(','),
+            used_field_group_count: String(fieldGroups.length),
+        });
+        expect(pushEventMock).toHaveBeenCalledTimes(1 + fieldGroups.length);
+        expect(pushEventMock).toHaveBeenCalledWith(PUNSJ_SUBMIT_FIELD_GROUP_EVENT, {
+            source: 'opprett_journalpost',
+            sakstype: 'PSB',
+            field_group: PSB_FIELD_GROUPS.ARBEIDSTID,
+        });
+        expect(getPunsjSourceForJournalpost(journalpostId)).toBe('unknown');
+    });
+
+    it('Skal ikke sende PSB submit-events når journalposten ikke kommer fra manuell opprettelse', () => {
+        const fieldGroups = trackPsbSubmitFromJournalpost(journalpostId, psbKvittering);
+
+        expect(fieldGroups).toEqual([]);
+        expect(pushEventMock).not.toHaveBeenCalled();
     });
 });

--- a/src/test/utils/faroEvents.spec.ts
+++ b/src/test/utils/faroEvents.spec.ts
@@ -1,0 +1,46 @@
+import { faro } from '@grafana/faro-web-sdk';
+import {
+    MANUAL_JOURNALPOST_FLOW_STARTED_EVENT,
+    pushFaroEvent,
+    trackManualJournalpostFlowStarted,
+} from '../../app/utils/faroEvents';
+
+jest.mock('@grafana/faro-web-sdk', () => ({
+    faro: {
+        api: {
+            pushEvent: jest.fn(),
+        },
+    },
+}));
+
+describe('faroEvents', () => {
+    const pushEventMock = faro.api.pushEvent as jest.Mock;
+
+    beforeEach(() => {
+        pushEventMock.mockClear();
+        delete window.nais;
+    });
+
+    it('Skal ikke sende event når collector url ikke er tilgjengelig', () => {
+        const result = pushFaroEvent('test_event', { source: 'test' });
+
+        expect(result).toBeFalsy();
+        expect(pushEventMock).not.toHaveBeenCalled();
+    });
+
+    it('Skal sende custom Faro-event for manuelt opprettet journalpost med trygge attributter', () => {
+        window.nais = {
+            telemetryCollectorURL: 'https://collector.example/collect',
+            app: { name: 'k9-punsj-frontend', version: 'test' },
+        };
+
+        const result = trackManualJournalpostFlowStarted();
+
+        expect(result).toBeTruthy();
+        expect(pushEventMock).toHaveBeenCalledWith(MANUAL_JOURNALPOST_FLOW_STARTED_EVENT, {
+            source: 'opprett_journalpost',
+            route: '/opprett-journalpost',
+            phase: 'page_opened',
+        });
+    });
+});


### PR DESCRIPTION
## Behov / bakgrunn

Vi ønsker å bruke eksisterende Faro til en første produktmåling i Punsj, for å se hvilke feltgrupper som faktisk brukes etter at saksbehandler selv oppretter journalpost.

## Løsning

- legger til en liten Faro helper for trygge custom events i frontend
- venter på `nais.js` før Faro initialiseres
- sender custom events for åpning av `Opprett journalpost`, start av `PSB`-flyt og vellykket innsending
- sender en bevisst smal feltgruppetaksonomi: `arbeidstid`, `trekk_av_periode`, `periode` og `annet`
- sender ikke persondata, fritekst eller interne id-er
- legger til målrettede tester