### PR TITLE
Fix missing k9saksnummer in søknad creation flow

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ Kort logg over merkbare repo-endringer og oppsettendringer.
 
 - Stopper create søknad-kall når `k9saksnummer` mangler eller er blankt, i stedet for å sende en request som backend ikke kan decode.
 - Leser `k9saksnummer` fra `fordelingState.fagsak` først og bruker `journalpost.sak` som fallback etter journalføring eller reload.
+- Prioriterer `journalpost.sak` når journalposten er ferdigstilt, og bruker `søknad.k9saksnummer` som fallback i OLP og PSB punch ved reload.
 - Bruker samme resolver i OLP kursperiodeoppslag og i eksisterende-søknad-tabellenes fagsak-sammenligning.
 
 ### OMPAO manual journalpost analytics (2026-04-24)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Kort logg over merkbare repo-endringer og oppsettendringer.
 
+### K9 saksnummer for create requests (2026-05-04)
+
+- Stopper create søknad-kall når `k9saksnummer` mangler eller er blankt, i stedet for å sende en request som backend ikke kan decode.
+- Leser `k9saksnummer` fra `fordelingState.fagsak` først og bruker `journalpost.sak` som fallback etter journalføring eller reload.
+- Bruker samme resolver i OLP kursperiodeoppslag og i eksisterende-søknad-tabellenes fagsak-sammenligning.
+
 ### OMPAO manual journalpost analytics (2026-04-24)
 
 - Sender nå `Faro` start- og submit-måling for `OMPAO` når flyten kommer fra manuelt opprettet journalpost.

--- a/src/app/models/types/OLPSoknad.ts
+++ b/src/app/models/types/OLPSoknad.ts
@@ -18,6 +18,7 @@ export interface IOLPSoknadBackend {
     begrunnelseForInnsending?: BegrunnelseForInnsending;
     bosteder?: Bosteder[];
     journalposter: string[];
+    k9saksnummer?: string;
     klokkeslett?: string;
     kurs?: Kurs;
     lovbestemtFerie?: Periode[];

--- a/src/app/models/types/RequestBodies.ts
+++ b/src/app/models/types/RequestBodies.ts
@@ -51,7 +51,7 @@ export interface IOpprettSoknad {
     norskIdent: string;
     journalpostId: string;
     pleietrengendeIdent: string | null;
-    k9saksnummer?: string;
+    k9saksnummer: string;
 }
 
 export interface IKopierJournalpost {

--- a/src/app/state/actions/EksisterendeSoknaderActions.ts
+++ b/src/app/state/actions/EksisterendeSoknaderActions.ts
@@ -2,6 +2,7 @@ import { ApiPath } from 'app/apiConfig';
 import { EksisterendeSoknaderActionKeys } from 'app/models/enums';
 import { IError } from 'app/models/types';
 import { convertResponseToError, get, post } from 'app/utils';
+import { createManglerK9saksnummerError, normalizeK9saksnummer } from 'app/utils/k9saksnummerUtils';
 
 import { IPSBSoknad } from '../../models/types/PSBSoknad';
 import { IOpprettSoknad } from '../../models/types/RequestBodies';
@@ -159,11 +160,17 @@ export function createSoknad(journalpostid: string, søkerId: string, barnIdent:
     return (dispatch: any) => {
         dispatch(createSoknadRequestAction());
 
+        const resolvedK9saksnummer = normalizeK9saksnummer(k9saksnummer);
+        if (!resolvedK9saksnummer) {
+            dispatch(createSoknadErrorAction(createManglerK9saksnummerError()));
+            return;
+        }
+
         const requestBody: IOpprettSoknad = {
             journalpostId: journalpostid,
             norskIdent: søkerId,
             pleietrengendeIdent: barnIdent,
-            k9saksnummer,
+            k9saksnummer: resolvedK9saksnummer,
         };
 
         post(ApiPath.PSB_SOKNAD_CREATE, undefined, undefined, requestBody, (response, soknad) => {

--- a/src/app/state/actions/OMSPunchFormActions.ts
+++ b/src/app/state/actions/OMSPunchFormActions.ts
@@ -2,6 +2,7 @@ import { ApiPath } from 'app/apiConfig';
 import { IPSBSoknad } from 'app/models/types';
 import { OMSKorrigering } from 'app/models/types/OMSKorrigering';
 import { apiUrl, get, initializeDate, post, put } from 'app/utils';
+import { manglerK9saksnummerMessage, normalizeK9saksnummer } from 'app/utils/k9saksnummerUtils';
 
 async function postPromise<BodyType>(
     path: string,
@@ -52,10 +53,16 @@ export function createOMSKorrigering(
     callback: (response: Response, data: any) => void,
     k9saksnummer?: string,
 ): void {
+    const resolvedK9saksnummer = normalizeK9saksnummer(k9saksnummer);
+    if (!resolvedK9saksnummer) {
+        callback({ ok: false, status: 400, statusText: manglerK9saksnummerMessage } as Response, undefined);
+        return;
+    }
+
     const requestBody = {
         journalpostId: journalpostid,
         norskIdent: søkerId,
-        k9saksnummer,
+        k9saksnummer: resolvedK9saksnummer,
     };
 
     post(ApiPath.OMS_SOKNAD_CREATE, undefined, undefined, requestBody, callback);

--- a/src/app/søknader/korrigeringAvInntektsmelding/containers/KorrigeringAvInntektsmeldingContainer.tsx
+++ b/src/app/søknader/korrigeringAvInntektsmelding/containers/KorrigeringAvInntektsmeldingContainer.tsx
@@ -2,12 +2,14 @@ import React, { useEffect, useState } from 'react';
 
 import { useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
+import { Alert } from '@navikt/ds-react';
 
 import { IPSBSoknad } from 'app/models/types';
 import { RootStateType } from 'app/state/RootState';
 import { createOMSKorrigering, hentOMSSøknad } from 'app/state/actions/OMSPunchFormActions';
 import KorrigeringAvInntektsmeldingForm from './KorrigeringAvInntektsmeldingForm';
 import { ROUTES } from 'app/constants/routes';
+import { manglerK9saksnummerMessage, resolveK9saksnummer } from 'app/utils/k9saksnummerUtils';
 
 const KorrigeringAvInntektsmeldingContainer: React.FC = () => {
     const { id } = useParams<{ id: string }>();
@@ -19,17 +21,28 @@ const KorrigeringAvInntektsmeldingContainer: React.FC = () => {
     const fordelingState = useSelector((state: RootStateType) => state.fordelingState);
 
     const [soknad, setSoknad] = useState<Partial<IPSBSoknad>>({});
+    const [opprettError, setOpprettError] = useState<string>();
 
     const { søkerId } = identState;
-    const { fagsak } = fordelingState;
-    const k9saksnummer = fagsak?.fagsakId;
+    const k9saksnummer = resolveK9saksnummer(fordelingState, journalpost);
 
     useEffect(() => {
         if (!id) {
+            if (!k9saksnummer) {
+                setOpprettError(manglerK9saksnummerMessage);
+                return;
+            }
+
+            setOpprettError(undefined);
             createOMSKorrigering(
                 søkerId,
                 journalpost?.journalpostId || '',
                 (response, data) => {
+                    if (!response.ok) {
+                        setOpprettError(response.statusText || 'Det oppstod en feil under opprettelse av søknad.');
+                        return;
+                    }
+
                     setSoknad(data);
                     navigate(`../${ROUTES.KORRIGERING_INNTEKTSMELDING_ID.replace(':id', data.soeknadId)}`);
                 },
@@ -42,10 +55,18 @@ const KorrigeringAvInntektsmeldingContainer: React.FC = () => {
                 setSoknad(response);
             });
         }
-    }, [søkerId, journalpost]);
+    }, [id, journalpost, k9saksnummer, navigate, søkerId]);
 
     const journalposterFraSoknad = soknad?.journalposter || [];
     const journalposter = Array.from(journalposterFraSoknad);
+
+    if (opprettError) {
+        return (
+            <Alert size="small" variant="error">
+                {opprettError}
+            </Alert>
+        );
+    }
 
     return (
         <KorrigeringAvInntektsmeldingForm

--- a/src/app/søknader/omsorgspenger-alene-om-omsorgen/api.ts
+++ b/src/app/søknader/omsorgspenger-alene-om-omsorgen/api.ts
@@ -3,6 +3,7 @@ import { UseMutationResult, useMutation } from '@tanstack/react-query';
 import { ApiPath } from 'app/apiConfig';
 import { ValideringResponse } from 'app/models/types/ValideringResponse';
 import { get, post, put } from 'app/utils';
+import { manglerK9saksnummerMessage, normalizeK9saksnummer } from 'app/utils/k9saksnummerUtils';
 
 import { IOMPAOSoknad } from './types/OMPAOSoknad';
 import { IOMPAOSoknadKvittering } from './types/OMPAOSoknadKvittering';
@@ -59,19 +60,25 @@ export const opprettSoeknad = (
     journalpostId: string,
     ident: string,
     pleietrengendeId: string,
-    k9saksnummer?: string,
-): Promise<IOMPAOSoknad> =>
-    post(ApiPath.OMP_AO_SOKNAD_CREATE, undefined, undefined, {
+    k9saksnummer: string,
+): Promise<IOMPAOSoknad> => {
+    const resolvedK9saksnummer = normalizeK9saksnummer(k9saksnummer);
+    if (!resolvedK9saksnummer) {
+        throw Error(manglerK9saksnummerMessage);
+    }
+
+    return post(ApiPath.OMP_AO_SOKNAD_CREATE, undefined, undefined, {
         journalpostId,
         norskIdent: ident,
         barnIdent: pleietrengendeId,
-        k9saksnummer,
+        k9saksnummer: resolvedK9saksnummer,
     }).then((response) => {
         if (!response.ok) {
             throw Error('Det oppstod en feil under opprettelse av søknad.');
         }
         return response.json();
     });
+};
 
 export const hentEksisterendeSoeknader = (ident: string): Promise<IOMPAOSoknadSvar> =>
     get(ApiPath.OMP_AO_EKSISTERENDE_SOKNADER_FIND, undefined, { 'X-Nav-NorskIdent': ident }).then((response) => {

--- a/src/app/søknader/omsorgspenger-alene-om-omsorgen/containers/EksisterendeOMPAOSoknader.tsx
+++ b/src/app/søknader/omsorgspenger-alene-om-omsorgen/containers/EksisterendeOMPAOSoknader.tsx
@@ -13,6 +13,7 @@ import { TimeFormat } from 'app/models/enums';
 import { IdentRules } from 'app/validation';
 import { datetime, dokumenterPreviewUtils } from 'app/utils';
 import intlHelper from 'app/utils/intlUtils';
+import { resolveK9saksnummer } from 'app/utils/k9saksnummerUtils';
 import { resetAllStateAction } from 'app/state/actions/GlobalActions';
 
 import { hentAlleJournalposterPerIdent } from 'app/api/api';
@@ -88,7 +89,7 @@ const EksisterendeOMPAOSoknader: React.FC<Props> = (props) => {
     const gaaVidereMedSoeknad = (soknad: IOMPAOSoknad) => {
         navigate(`../${ROUTES.PUNCH.replace(':id', soknad.soeknadId)}`);
     };
-    const fagsakId = fellesState.journalpost?.sak?.fagsakId || fordelingState?.fagsak?.fagsakId;
+    const fagsakId = resolveK9saksnummer(fordelingState, fellesState.journalpost);
 
     const showSoknader = () => {
         const modaler: Array<JSX.Element> = [];

--- a/src/app/søknader/omsorgspenger-alene-om-omsorgen/containers/OMPAORegistreringsValg.tsx
+++ b/src/app/søknader/omsorgspenger-alene-om-omsorgen/containers/OMPAORegistreringsValg.tsx
@@ -7,6 +7,7 @@ import { useLocation, useNavigate } from 'react-router';
 import { Alert, Button, Loader } from '@navikt/ds-react';
 
 import { ROUTES } from 'app/constants/routes';
+import { manglerK9saksnummerMessage, resolveK9saksnummer } from 'app/utils/k9saksnummerUtils';
 import { IIdentState } from '../../../models/types/IdentState';
 import { RootStateType } from '../../../state/RootState';
 import api, { hentEksisterendeSoeknader } from '../api';
@@ -31,7 +32,8 @@ export const RegistreringsValgComponent: React.FC<IOMPAORegistreringsValgProps> 
     const { søkerId, pleietrengendeId } = identState;
 
     const fordelingState = useSelector((state: RootStateType) => state.fordelingState);
-    const k9saksnummer = fordelingState.fagsak?.fagsakId;
+    const journalpost = useSelector((state: RootStateType) => state.felles.journalpost);
+    const k9saksnummer = resolveK9saksnummer(fordelingState, journalpost);
 
     const { data: eksisterendeSoeknader, isPending: isEksisterendeSoknaderLoading } = useQuery({
         queryKey: ['hentSoeknaderOMPAO'],
@@ -43,7 +45,12 @@ export const RegistreringsValgComponent: React.FC<IOMPAORegistreringsValgProps> 
         error: opprettSoknadError,
         mutate: opprettSoknad,
     } = useMutation({
-        mutationFn: () => api.opprettSoeknad(journalpostid, søkerId, pleietrengendeId, k9saksnummer),
+        mutationFn: () => {
+            if (!k9saksnummer) {
+                throw Error(manglerK9saksnummerMessage);
+            }
+            return api.opprettSoeknad(journalpostid, søkerId, pleietrengendeId, k9saksnummer);
+        },
         onSuccess: (soeknad) => {
             navigate(`../${ROUTES.PUNCH.replace(':id', soeknad?.soeknadId)}`);
         },
@@ -59,16 +66,16 @@ export const RegistreringsValgComponent: React.FC<IOMPAORegistreringsValgProps> 
     // Starte søknad automatisk hvis ingen søknader finnes
     useEffect(() => {
         const soknader = eksisterendeSoeknader?.søknader;
-        if (soknader?.length === 0) {
+        if (soknader?.length === 0 && k9saksnummer) {
             opprettSoknad();
         }
-    }, [eksisterendeSoeknader?.søknader, opprettSoknad]);
+    }, [eksisterendeSoeknader?.søknader, k9saksnummer, opprettSoknad]);
 
     const kanStarteNyRegistrering = () => {
         const soknader = eksisterendeSoeknader?.søknader;
         if (soknader?.length) {
             return !soknader?.some((soknad) =>
-                Array.from(soknad?.journalposter || []).some((journalpost) => journalpost === journalpostid),
+                Array.from(soknad?.journalposter || []).some((jpId) => jpId === journalpostid),
             );
         }
         return true;
@@ -85,6 +92,11 @@ export const RegistreringsValgComponent: React.FC<IOMPAORegistreringsValgProps> 
     return (
         <div className="registrering-page">
             <EksisterendeOMPAOSoknader søkerId={søkerId} pleietrengendeId={pleietrengendeId} />
+            {!k9saksnummer && (
+                <Alert size="small" variant="warning">
+                    {manglerK9saksnummerMessage}
+                </Alert>
+            )}
 
             <div className="knapperad">
                 <Button
@@ -101,7 +113,7 @@ export const RegistreringsValgComponent: React.FC<IOMPAORegistreringsValgProps> 
                         onClick={() => opprettSoknad()}
                         className="knapp knapp2"
                         size="small"
-                        disabled={isEksisterendeSoknaderLoading}
+                        disabled={isEksisterendeSoknaderLoading || !k9saksnummer}
                     >
                         {oppretterSoknad ? <Loader /> : <FormattedMessage id="ident.knapp.nyregistrering" />}
                     </Button>

--- a/src/app/søknader/omsorgspenger-kronisk-sykt-barn/containers/EksisterendeOMPKSSoknader.tsx
+++ b/src/app/søknader/omsorgspenger-kronisk-sykt-barn/containers/EksisterendeOMPKSSoknader.tsx
@@ -10,6 +10,7 @@ import { IdentRules } from 'app/validation';
 import { RootStateType } from 'app/state/RootState';
 import { datetime, dokumenterPreviewUtils } from 'app/utils';
 import intlHelper from 'app/utils/intlUtils';
+import { resolveK9saksnummer } from 'app/utils/k9saksnummerUtils';
 import { ROUTES } from 'app/constants/routes';
 import { resetAllStateAction } from 'app/state/actions/GlobalActions';
 
@@ -122,7 +123,7 @@ export const EksisterendeOMPKSSoknaderComponent: React.FunctionComponent<IEksist
         }
     };
 
-    const fagsakId = journalpost?.sak?.fagsakId || fordelingState?.fagsak?.fagsakId;
+    const fagsakId = resolveK9saksnummer(fordelingState, journalpost);
 
     const showSoknader = () => {
         const modaler: Array<JSX.Element> = [];

--- a/src/app/søknader/omsorgspenger-kronisk-sykt-barn/containers/OMPKSRegistreringsValg.tsx
+++ b/src/app/søknader/omsorgspenger-kronisk-sykt-barn/containers/OMPKSRegistreringsValg.tsx
@@ -8,6 +8,7 @@ import { Alert, Button } from '@navikt/ds-react';
 import { ROUTES } from 'app/constants/routes';
 
 import { findEksisterendeSoknader } from 'app/state/actions';
+import { manglerK9saksnummerMessage, resolveK9saksnummer } from 'app/utils/k9saksnummerUtils';
 import { IdentRules } from 'app/validation';
 import { IIdentState } from '../../../models/types/IdentState';
 import { RootStateType } from '../../../state/RootState';
@@ -43,7 +44,8 @@ export const RegistreringsValgComponent: React.FC<IOMPKSRegistreringsValgProps> 
     const location = useLocation();
 
     const fordelingState = useSelector((state: RootStateType) => state.fordelingState);
-    const k9saksnummer = fordelingState.fagsak?.fagsakId;
+    const journalpost = useSelector((state: RootStateType) => state.felles.journalpost);
+    const k9saksnummer = resolveK9saksnummer(fordelingState, journalpost);
 
     const {
         journalpostid,
@@ -81,10 +83,10 @@ export const RegistreringsValgComponent: React.FC<IOMPKSRegistreringsValgProps> 
 
     // Starte søknad automatisk hvis ingen søknader finnes
     useEffect(() => {
-        if (søknader?.length === 0) {
+        if (søknader?.length === 0 && k9saksnummer) {
             createSoknad(journalpostid, søkerId, pleietrengendeId, k9saksnummer);
         }
-    }, [createSoknad, journalpostid, pleietrengendeId, søkerId, søknader]);
+    }, [createSoknad, journalpostid, k9saksnummer, pleietrengendeId, søkerId, søknader]);
 
     useEffect(() => {
         if (isSoknadCreated && soknadid) {
@@ -116,6 +118,11 @@ export const RegistreringsValgComponent: React.FC<IOMPKSRegistreringsValgProps> 
                 pleietrengendeId={pleietrengendeId}
                 kanStarteNyRegistrering={kanStarteNyRegistrering()}
             />
+            {!k9saksnummer && (
+                <Alert size="small" variant="warning">
+                    {manglerK9saksnummerMessage}
+                </Alert>
+            )}
 
             <div className="knapperad">
                 <Button
@@ -132,7 +139,7 @@ export const RegistreringsValgComponent: React.FC<IOMPKSRegistreringsValgProps> 
                         onClick={() => createSoknad(journalpostid, søkerId, pleietrengendeId, k9saksnummer)}
                         className="knapp knapp2"
                         size="small"
-                        disabled={isEksisterendeSoknaderLoading}
+                        disabled={isEksisterendeSoknaderLoading || !k9saksnummer}
                     >
                         <FormattedMessage id="ident.knapp.nyregistrering" />
                     </Button>

--- a/src/app/søknader/omsorgspenger-kronisk-sykt-barn/state/actions/EksisterendeOMPKSSoknaderActions.ts
+++ b/src/app/søknader/omsorgspenger-kronisk-sykt-barn/state/actions/EksisterendeOMPKSSoknaderActions.ts
@@ -1,6 +1,7 @@
 import { ApiPath } from 'app/apiConfig';
 import { IError } from 'app/models/types';
 import { convertResponseToError, get, post } from 'app/utils';
+import { createManglerK9saksnummerError, normalizeK9saksnummer } from 'app/utils/k9saksnummerUtils';
 
 import { IOpprettSoknad } from '../../../../models/types/RequestBodies';
 import { EksisterendeOMPKSSoknaderActionKeys } from '../../types/EksisterendeOMPKSSoknaderActionKeys';
@@ -172,11 +173,17 @@ export function createOMPKSSoknad(
     return (dispatch: any) => {
         dispatch(createOMPKSSoknadRequestAction());
 
+        const resolvedK9saksnummer = normalizeK9saksnummer(k9saksnummer);
+        if (!resolvedK9saksnummer) {
+            dispatch(createOMPKSSoknadErrorAction(createManglerK9saksnummerError()));
+            return;
+        }
+
         const requestBody: IOpprettSoknad = {
             journalpostId: journalpostid,
             norskIdent: søkerId,
             pleietrengendeIdent: barnIdent,
-            k9saksnummer,
+            k9saksnummer: resolvedK9saksnummer,
         };
 
         post(ApiPath.OMP_KS_SOKNAD_CREATE, undefined, undefined, requestBody, (response, soknad) => {

--- a/src/app/søknader/omsorgspenger-midlertidig-alene/containers/OMPMARegistreringsValg.tsx
+++ b/src/app/søknader/omsorgspenger-midlertidig-alene/containers/OMPMARegistreringsValg.tsx
@@ -8,6 +8,7 @@ import { Alert, Button } from '@navikt/ds-react';
 import { ROUTES } from 'app/constants/routes';
 
 import { findEksisterendeSoknader } from 'app/state/actions';
+import { manglerK9saksnummerMessage, resolveK9saksnummer } from 'app/utils/k9saksnummerUtils';
 import { IdentRules } from 'app/validation';
 import { IIdentState } from '../../../models/types/IdentState';
 import { RootStateType } from '../../../state/RootState';
@@ -43,7 +44,8 @@ export const RegistreringsValgComponent: React.FC<IOMPMARegistreringsValgProps> 
     const location = useLocation();
 
     const fordelingState = useSelector((state: RootStateType) => state.fordelingState);
-    const k9saksnummer = fordelingState.fagsak?.fagsakId;
+    const journalpost = useSelector((state: RootStateType) => state.felles.journalpost);
+    const k9saksnummer = resolveK9saksnummer(fordelingState, journalpost);
 
     const {
         journalpostid,
@@ -82,10 +84,10 @@ export const RegistreringsValgComponent: React.FC<IOMPMARegistreringsValgProps> 
 
     // Starte søknad automatisk hvis ingen søknader finnes
     useEffect(() => {
-        if (søknader?.length === 0) {
+        if (søknader?.length === 0 && k9saksnummer) {
             createSoknad(journalpostid, søkerId, annenPart, k9saksnummer);
         }
-    }, [annenPart, createSoknad, eksisterendeSoknaderSvar, journalpostid, søkerId, søknader]);
+    }, [annenPart, createSoknad, eksisterendeSoknaderSvar, journalpostid, k9saksnummer, søkerId, søknader]);
 
     useEffect(() => {
         if (eksisterendeSoknaderSvar && isSoknadCreated && soknadid) {
@@ -119,6 +121,11 @@ export const RegistreringsValgComponent: React.FC<IOMPMARegistreringsValgProps> 
                 fagsakId={k9saksnummer || ''}
                 kanStarteNyRegistrering={kanStarteNyRegistrering()}
             />
+            {!k9saksnummer && (
+                <Alert size="small" variant="warning">
+                    {manglerK9saksnummerMessage}
+                </Alert>
+            )}
 
             <div className="knapperad">
                 <Button
@@ -135,7 +142,7 @@ export const RegistreringsValgComponent: React.FC<IOMPMARegistreringsValgProps> 
                         onClick={() => createSoknad(journalpostid, søkerId, annenPart, k9saksnummer)}
                         className="knapp knapp2"
                         size="small"
-                        disabled={isEksisterendeSoknaderLoading}
+                        disabled={isEksisterendeSoknaderLoading || !k9saksnummer}
                     >
                         <FormattedMessage id="ident.knapp.nyregistrering" />
                     </Button>

--- a/src/app/søknader/omsorgspenger-midlertidig-alene/state/actions/EksisterendeOMPMASoknaderActions.ts
+++ b/src/app/søknader/omsorgspenger-midlertidig-alene/state/actions/EksisterendeOMPMASoknaderActions.ts
@@ -1,6 +1,7 @@
 import { ApiPath } from 'app/apiConfig';
 import { IError } from 'app/models/types';
 import { convertResponseToError, get, post } from 'app/utils';
+import { createManglerK9saksnummerError, normalizeK9saksnummer } from 'app/utils/k9saksnummerUtils';
 
 import { EksisterendeOMPMASoknaderActionKeys } from '../../types/EksisterendeOMPMASoknaderActionKeys';
 import { IOMPMASoknad } from '../../types/OMPMASoknad';
@@ -62,7 +63,7 @@ interface IOpprettMASoknad {
     norskIdent: string;
     annenPart: string;
     barn: string[];
-    k9saksnummer?: string;
+    k9saksnummer: string;
 }
 
 type IMapperOMPMAActionTypes =
@@ -174,13 +175,19 @@ export function createOMPMASoknad(journalpostid: string, søkerId: string, annen
     return (dispatch: any) => {
         dispatch(createOMPMASoknadRequestAction());
 
+        const resolvedK9saksnummer = normalizeK9saksnummer(k9saksnummer);
+        if (!resolvedK9saksnummer) {
+            dispatch(createOMPMASoknadErrorAction(createManglerK9saksnummerError()));
+            return;
+        }
+
         const requestBody: IOpprettMASoknad = {
             journalpostId: journalpostid,
             norskIdent: søkerId,
             annenPart,
             // 07.05.2022 barn kan fjernes etter backend tillater opprettelse av søknad uten
             barn: [],
-            k9saksnummer,
+            k9saksnummer: resolvedK9saksnummer,
         };
 
         post(ApiPath.OMP_MA_SOKNAD_CREATE, undefined, undefined, requestBody, (response, soknad) => {

--- a/src/app/søknader/omsorgspenger-utbetaling/api.ts
+++ b/src/app/søknader/omsorgspenger-utbetaling/api.ts
@@ -2,6 +2,7 @@ import { ApiPath } from 'app/apiConfig';
 import { IPeriode, Periode } from 'app/models/types';
 import { ValideringResponse } from 'app/models/types/ValideringResponse';
 import { get, post, put } from 'app/utils';
+import { manglerK9saksnummerMessage, normalizeK9saksnummer } from 'app/utils/k9saksnummerUtils';
 
 import { IOMPUTSoknadBackend } from './types/OMPUTSoknad';
 import { IOMPUTSoknadKvittering } from './types/OMPUTSoknadKvittering';
@@ -70,18 +71,24 @@ export const sendSoeknad = async (
 export const opprettSoeknad = (
     journalpostId: string,
     ident: string,
-    k9saksnummer?: string,
-): Promise<IOMPUTSoknadBackend> =>
-    post(ApiPath.OMP_UT_SOKNAD_CREATE, undefined, undefined, {
+    k9saksnummer: string,
+): Promise<IOMPUTSoknadBackend> => {
+    const resolvedK9saksnummer = normalizeK9saksnummer(k9saksnummer);
+    if (!resolvedK9saksnummer) {
+        throw Error(manglerK9saksnummerMessage);
+    }
+
+    return post(ApiPath.OMP_UT_SOKNAD_CREATE, undefined, undefined, {
         journalpostId,
         norskIdent: ident,
-        k9saksnummer,
+        k9saksnummer: resolvedK9saksnummer,
     }).then((response) => {
         if (!response.ok) {
             throw Error('Det oppstod en feil under opprettelse av søknad.');
         }
         return response.json();
     });
+};
 
 export const hentEksisterendeSoeknader = (ident: string): Promise<IOMPUTSoknadSvar> =>
     get(ApiPath.OMP_UT_EKSISTERENDE_SOKNADER_FIND, undefined, { 'X-Nav-NorskIdent': ident }).then((response) => {

--- a/src/app/søknader/omsorgspenger-utbetaling/containers/EksisterendeOMPUTSoknader.tsx
+++ b/src/app/søknader/omsorgspenger-utbetaling/containers/EksisterendeOMPUTSoknader.tsx
@@ -13,6 +13,7 @@ import { TimeFormat } from 'app/models/enums';
 import { IdentRules } from 'app/validation';
 import { datetime, dokumenterPreviewUtils } from 'app/utils';
 import intlHelper from 'app/utils/intlUtils';
+import { resolveK9saksnummer } from 'app/utils/k9saksnummerUtils';
 
 import { hentAlleJournalposterPerIdent } from 'app/api/api';
 import DokumentIdList from 'app/components/dokumentId-list/DokumentIdList';
@@ -86,7 +87,7 @@ export const EksisterendeOMPUTSoknader: React.FC<IEksisterendeOMPUTSoknaderCompo
     const gaaVidereMedSoeknad = (soknad: IOMPUTSoknad) => {
         navigate(`../${ROUTES.PUNCH.replace(':id', soknad.soeknadId)}`);
     };
-    const fagsakId = fellesState.journalpost?.sak?.fagsakId || fordelingState?.fagsak?.fagsakId;
+    const fagsakId = resolveK9saksnummer(fordelingState, fellesState.journalpost);
 
     const showSoknader = () => {
         const modaler: Array<JSX.Element> = [];

--- a/src/app/søknader/omsorgspenger-utbetaling/containers/OMPUTRegistreringsValg.tsx
+++ b/src/app/søknader/omsorgspenger-utbetaling/containers/OMPUTRegistreringsValg.tsx
@@ -7,6 +7,8 @@ import { useLocation, useNavigate } from 'react-router';
 import { Alert, Button, Loader } from '@navikt/ds-react';
 
 import { ROUTES } from 'app/constants/routes';
+import { IJournalpost } from 'app/models/types';
+import { manglerK9saksnummerMessage, resolveK9saksnummer } from 'app/utils/k9saksnummerUtils';
 
 import { IFordelingState } from '../../../models/types/FordelingState';
 import { IIdentState } from '../../../models/types/IdentState';
@@ -20,6 +22,7 @@ export interface IOMPUTRegistreringsValgComponentProps {
 export interface IEksisterendeOMPUTSoknaderStateProps {
     identState: IIdentState;
     fordelingState: IFordelingState;
+    journalpost?: IJournalpost;
 }
 
 type IOMPUTRegistreringsValgProps = IOMPUTRegistreringsValgComponentProps & IEksisterendeOMPUTSoknaderStateProps;
@@ -30,10 +33,9 @@ export const RegistreringsValgComponent: React.FC<IOMPUTRegistreringsValgProps> 
     const navigate = useNavigate();
     const location = useLocation();
 
-    const { journalpostid, identState, fordelingState } = props;
+    const { journalpostid, identState, fordelingState, journalpost } = props;
     const { søkerId, pleietrengendeId } = identState;
-    const { fagsak } = fordelingState;
-    const k9saksnummer = fagsak?.fagsakId;
+    const k9saksnummer = resolveK9saksnummer(fordelingState, journalpost);
 
     // Redirect tilbake ved side reload
     useEffect(() => {
@@ -47,7 +49,12 @@ export const RegistreringsValgComponent: React.FC<IOMPUTRegistreringsValgProps> 
         error: opprettSoknadError,
         mutate: opprettSoknad,
     } = useMutation({
-        mutationFn: () => api.opprettSoeknad(journalpostid, søkerId, k9saksnummer),
+        mutationFn: () => {
+            if (!k9saksnummer) {
+                throw Error(manglerK9saksnummerMessage);
+            }
+            return api.opprettSoeknad(journalpostid, søkerId, k9saksnummer);
+        },
         onSuccess: (soeknad) => {
             navigate(`../${ROUTES.PUNCH.replace(':id', soeknad.soeknadId)}`);
         },
@@ -65,10 +72,10 @@ export const RegistreringsValgComponent: React.FC<IOMPUTRegistreringsValgProps> 
     // Starte søknad automatisk hvis ingen søknader finnes
     useEffect(() => {
         const soknader = eksisterendeSoeknader?.søknader;
-        if (soknader?.length === 0) {
+        if (soknader?.length === 0 && k9saksnummer) {
             opprettSoknad();
         }
-    }, [eksisterendeSoeknader?.søknader, opprettSoknad]);
+    }, [eksisterendeSoeknader?.søknader, k9saksnummer, opprettSoknad]);
 
     if (opprettSoknadError instanceof Error) {
         return (
@@ -82,7 +89,7 @@ export const RegistreringsValgComponent: React.FC<IOMPUTRegistreringsValgProps> 
         const soknader = eksisterendeSoeknader?.søknader;
         if (soknader?.length) {
             return !soknader?.some((soknad) =>
-                Array.from(soknad?.journalposter || []).some((journalpost) => journalpost === journalpostid),
+                Array.from(soknad?.journalposter || []).some((jpId) => jpId === journalpostid),
             );
         }
         return true;
@@ -95,6 +102,11 @@ export const RegistreringsValgComponent: React.FC<IOMPUTRegistreringsValgProps> 
                 pleietrengendeId={pleietrengendeId}
                 kanStarteNyRegistrering={kanStarteNyRegistrering()}
             />
+            {!k9saksnummer && (
+                <Alert size="small" variant="warning">
+                    {manglerK9saksnummerMessage}
+                </Alert>
+            )}
 
             <div className="knapperad">
                 <Button
@@ -111,7 +123,7 @@ export const RegistreringsValgComponent: React.FC<IOMPUTRegistreringsValgProps> 
                         onClick={() => opprettSoknad()}
                         className="knapp knapp2"
                         size="small"
-                        disabled={isEksisterendeSoknaderLoading}
+                        disabled={isEksisterendeSoknaderLoading || !k9saksnummer}
                     >
                         {oppretterSoknad ? <Loader /> : <FormattedMessage id="ident.knapp.nyregistrering" />}
                     </Button>
@@ -123,6 +135,7 @@ export const RegistreringsValgComponent: React.FC<IOMPUTRegistreringsValgProps> 
 const mapStateToProps = (state: RootStateType): IEksisterendeOMPUTSoknaderStateProps => ({
     identState: state.identState,
     fordelingState: state.fordelingState,
+    journalpost: state.felles.journalpost,
 });
 
 export const OMPUTRegistreringsValg = connect(mapStateToProps)(RegistreringsValgComponent);

--- a/src/app/søknader/opplæringspenger/api.ts
+++ b/src/app/søknader/opplæringspenger/api.ts
@@ -2,6 +2,7 @@ import { ApiPath } from 'app/apiConfig';
 import { Periode } from 'app/models/types';
 import { ValideringResponse } from 'app/models/types/ValideringResponse';
 import { get, post, put } from 'app/utils';
+import { manglerK9saksnummerMessage, normalizeK9saksnummer } from 'app/utils/k9saksnummerUtils';
 
 import { IOLPSoknadBackend } from '../../models/types/OLPSoknad';
 import { IOLPSoknadKvittering } from './OLPSoknadKvittering';
@@ -98,19 +99,25 @@ export const opprettSoeknad = (
     journalpostId: string,
     ident: string,
     pleietrengendeId: string,
-    k9saksnummer?: string,
-): Promise<IOLPSoknadBackend> =>
-    post(ApiPath.OLP_SOKNAD_CREATE, undefined, undefined, {
+    k9saksnummer: string,
+): Promise<IOLPSoknadBackend> => {
+    const resolvedK9saksnummer = normalizeK9saksnummer(k9saksnummer);
+    if (!resolvedK9saksnummer) {
+        throw Error(manglerK9saksnummerMessage);
+    }
+
+    return post(ApiPath.OLP_SOKNAD_CREATE, undefined, undefined, {
         journalpostId,
         norskIdent: ident,
         pleietrengendeId,
-        k9saksnummer,
+        k9saksnummer: resolvedK9saksnummer,
     }).then((response) => {
         if (!response.ok) {
             throw Error('Det oppstod en feil under opprettelse av søknad.');
         }
         return response.json();
     });
+};
 
 export const hentEksisterendeSoeknader = (ident: string): Promise<IOLPSoknadMappe> =>
     get(ApiPath.OLP_EKSISTERENDE_SOKNADER_FIND, undefined, { 'X-Nav-NorskIdent': ident }).then((response) => {

--- a/src/app/søknader/opplæringspenger/containers/OLPPunchFormContainer.tsx
+++ b/src/app/søknader/opplæringspenger/containers/OLPPunchFormContainer.tsx
@@ -47,7 +47,6 @@ const OLPPunchFormContainer = (props: IPunchOLPFormProps) => {
     const dispatch = useDispatch();
     const fellesState = useSelector((state: RootStateType) => state.felles);
     const fordelingState = useSelector((state: RootStateType) => state.fordelingState);
-    const k9saksnummer = resolveK9saksnummer(fordelingState, fellesState.journalpost);
     const intl = useIntl();
 
     const {
@@ -73,6 +72,7 @@ const OLPPunchFormContainer = (props: IPunchOLPFormProps) => {
         queryKey: [id],
         queryFn: () => hentSoeknad(identState.søkerId, id),
     });
+    const k9saksnummer = resolveK9saksnummer(fordelingState, fellesState.journalpost, soeknadRespons);
 
     useEffect(() => {
         if (soeknadRespons) {

--- a/src/app/søknader/opplæringspenger/containers/OLPPunchFormContainer.tsx
+++ b/src/app/søknader/opplæringspenger/containers/OLPPunchFormContainer.tsx
@@ -14,6 +14,7 @@ import { RootStateType } from 'app/state/RootState';
 import intlHelper from 'app/utils/intlUtils';
 import { resetAllStateAction } from 'app/state/actions/GlobalActions';
 import { ROUTES } from 'app/constants/routes';
+import { resolveK9saksnummer } from 'app/utils/k9saksnummerUtils';
 
 import { hentEksisterendePerioderForSaksnummer, hentSoeknad, sendSoeknad } from '../api';
 import { initialValues } from '../initialValues';
@@ -45,6 +46,8 @@ const OLPPunchFormContainer = (props: IPunchOLPFormProps) => {
     const navigate = useNavigate();
     const dispatch = useDispatch();
     const fellesState = useSelector((state: RootStateType) => state.felles);
+    const fordelingState = useSelector((state: RootStateType) => state.fordelingState);
+    const k9saksnummer = resolveK9saksnummer(fordelingState, fellesState.journalpost);
     const intl = useIntl();
 
     const {
@@ -76,10 +79,10 @@ const OLPPunchFormContainer = (props: IPunchOLPFormProps) => {
             hentPerioderK9({
                 ident: soeknadRespons.soekerId,
                 barnIdent: soeknadRespons.barn?.norskIdent || identState.pleietrengendeId,
-                saksnummer: fellesState.journalpost?.sak?.fagsakId || '',
+                saksnummer: k9saksnummer || '',
             });
         }
-    }, [soeknadRespons, hentPerioderK9, identState.pleietrengendeId]);
+    }, [soeknadRespons, hentPerioderK9, identState.pleietrengendeId, k9saksnummer]);
 
     useEffect(() => {
         trackOlpStartedFromJournalpost(props.journalpostid);

--- a/src/app/søknader/opplæringspenger/containers/OLPRegistreringsValg.tsx
+++ b/src/app/søknader/opplæringspenger/containers/OLPRegistreringsValg.tsx
@@ -7,6 +7,7 @@ import { useLocation, useNavigate } from 'react-router';
 import { Alert, Button } from '@navikt/ds-react';
 
 import { ROUTES } from 'app/constants/routes';
+import { manglerK9saksnummerMessage, resolveK9saksnummer } from 'app/utils/k9saksnummerUtils';
 import { IIdentState } from '../../../models/types/IdentState';
 import { RootStateType } from '../../../state/RootState';
 import api, { hentEksisterendeSoeknader } from '../api';
@@ -31,7 +32,8 @@ export const RegistreringsValgComponent: React.FunctionComponent<IOLPRegistrerin
     const { søkerId, pleietrengendeId } = identState;
 
     const fordelingState = useSelector((state: RootStateType) => state.fordelingState);
-    const k9saksnummer = fordelingState.fagsak?.fagsakId;
+    const journalpost = useSelector((state: RootStateType) => state.felles.journalpost);
+    const k9saksnummer = resolveK9saksnummer(fordelingState, journalpost);
 
     // Redirect tilbake ved side reload
     useEffect(() => {
@@ -45,7 +47,12 @@ export const RegistreringsValgComponent: React.FunctionComponent<IOLPRegistrerin
         error: opprettSoknadError,
         mutate: opprettSoknad,
     } = useMutation({
-        mutationFn: () => api.opprettSoeknad(journalpostid, søkerId, pleietrengendeId, k9saksnummer),
+        mutationFn: () => {
+            if (!k9saksnummer) {
+                throw Error(manglerK9saksnummerMessage);
+            }
+            return api.opprettSoeknad(journalpostid, søkerId, pleietrengendeId, k9saksnummer);
+        },
         onSuccess: (soeknad) => {
             navigate(`../${ROUTES.PUNCH.replace(':id', soeknad?.soeknadId)}`);
         },
@@ -59,10 +66,10 @@ export const RegistreringsValgComponent: React.FunctionComponent<IOLPRegistrerin
     // Starte søknad automatisk hvis ingen søknader finnes
     useEffect(() => {
         const soknader = eksisterendeSoeknader?.søknader;
-        if (soknader?.length === 0) {
+        if (soknader?.length === 0 && k9saksnummer) {
             opprettSoknad();
         }
-    }, [eksisterendeSoeknader?.søknader, opprettSoknad]);
+    }, [eksisterendeSoeknader?.søknader, k9saksnummer, opprettSoknad]);
 
     if (opprettSoknadError instanceof Error) {
         return (
@@ -76,7 +83,7 @@ export const RegistreringsValgComponent: React.FunctionComponent<IOLPRegistrerin
         const soknader = eksisterendeSoeknader?.søknader;
         if (soknader?.length) {
             return !soknader?.some((soknad) =>
-                Array.from(soknad?.journalposter || []).some((journalpost) => journalpost === journalpostid),
+                Array.from(soknad?.journalposter || []).some((jpId) => jpId === journalpostid),
             );
         }
         return true;
@@ -85,6 +92,11 @@ export const RegistreringsValgComponent: React.FunctionComponent<IOLPRegistrerin
     return (
         <div className="registrering-page">
             <EksisterendeOLPSoknader søkerId={søkerId} pleietrengendeId={pleietrengendeId} />
+            {!k9saksnummer && (
+                <Alert size="small" variant="warning">
+                    {manglerK9saksnummerMessage}
+                </Alert>
+            )}
 
             <div className="knapperad">
                 <Button
@@ -102,6 +114,7 @@ export const RegistreringsValgComponent: React.FunctionComponent<IOLPRegistrerin
                         onClick={() => opprettSoknad()}
                         className="knapp knapp2"
                         size="small"
+                        disabled={!k9saksnummer}
                     >
                         <FormattedMessage id="ident.knapp.nyregistrering" />
                     </Button>

--- a/src/app/søknader/pleiepenger-livets-sluttfase/containers/EksisterendePLSSoknader.tsx
+++ b/src/app/søknader/pleiepenger-livets-sluttfase/containers/EksisterendePLSSoknader.tsx
@@ -11,6 +11,7 @@ import { RootStateType } from 'app/state/RootState';
 import { ROUTES } from 'app/constants/routes';
 import { datetime, dokumenterPreviewUtils } from 'app/utils';
 import intlHelper from 'app/utils/intlUtils';
+import { resolveK9saksnummer } from 'app/utils/k9saksnummerUtils';
 import { resetAllStateAction } from 'app/state/actions/GlobalActions';
 import { IJournalposterPerIdentState } from 'app/models/types/Journalpost/JournalposterPerIdentState';
 import DokumentIdList from 'app/components/dokumentId-list/DokumentIdList';
@@ -127,7 +128,7 @@ export const EksisterendePLSSoknaderComponent: React.FC<Props> = (props: Props) 
         }
     };
 
-    const fagsakId = journalpost?.sak?.fagsakId || fordelingState?.fagsak?.fagsakId;
+    const fagsakId = resolveK9saksnummer(fordelingState, journalpost);
 
     const showSoknader = () => {
         const modaler: Array<JSX.Element> = [];

--- a/src/app/søknader/pleiepenger-livets-sluttfase/containers/PLSRegistreringsValg.tsx
+++ b/src/app/søknader/pleiepenger-livets-sluttfase/containers/PLSRegistreringsValg.tsx
@@ -8,6 +8,7 @@ import { Alert, Button } from '@navikt/ds-react';
 import { ROUTES } from 'app/constants/routes';
 import { IdentRules } from 'app/validation';
 import { findEksisterendeSoknader } from 'app/state/actions';
+import { manglerK9saksnummerMessage, resolveK9saksnummer } from 'app/utils/k9saksnummerUtils';
 import { IIdentState } from '../../../models/types/IdentState';
 import { RootStateType } from '../../../state/RootState';
 import { hentAlleJournalposterForIdent as hentAlleJournalposterPerIdentAction } from '../../../state/actions/JournalposterPerIdentActions';
@@ -44,7 +45,8 @@ export const PLSRegistreringsValgComponent: React.FunctionComponent<IPLSRegistre
     const location = useLocation();
 
     const fordelingState = useSelector((state: RootStateType) => state.fordelingState);
-    const k9saksnummer = fordelingState.fagsak?.fagsakId;
+    const journalpost = useSelector((state: RootStateType) => state.felles.journalpost);
+    const k9saksnummer = resolveK9saksnummer(fordelingState, journalpost);
 
     const {
         journalpostid,
@@ -82,10 +84,10 @@ export const PLSRegistreringsValgComponent: React.FunctionComponent<IPLSRegistre
 
     // Starte søknad automatisk hvis ingen søknader finnes
     useEffect(() => {
-        if (søknader?.length === 0) {
+        if (søknader?.length === 0 && k9saksnummer) {
             createSoknad(journalpostid, søkerId, pleietrengendeId, k9saksnummer);
         }
-    }, [createSoknad, journalpostid, søkerId, pleietrengendeId, søknader?.length]);
+    }, [createSoknad, journalpostid, k9saksnummer, søkerId, pleietrengendeId, søknader?.length]);
 
     useEffect(() => {
         if (eksisterendeSoknaderSvar && isSoknadCreated && soknadid) {
@@ -116,6 +118,11 @@ export const PLSRegistreringsValgComponent: React.FunctionComponent<IPLSRegistre
                 pleietrengendeId={pleietrengendeId}
                 kanStarteNyRegistrering={kanStarteNyRegistrering()}
             />
+            {!k9saksnummer && (
+                <Alert size="small" variant="warning">
+                    {manglerK9saksnummerMessage}
+                </Alert>
+            )}
             <div className="knapperad">
                 <Button
                     variant="secondary"
@@ -131,7 +138,7 @@ export const PLSRegistreringsValgComponent: React.FunctionComponent<IPLSRegistre
                         onClick={() => createSoknad(journalpostid, søkerId, pleietrengendeId, k9saksnummer)}
                         className="knapp knapp2"
                         size="small"
-                        disabled={isEksisterendeSoknaderLoading}
+                        disabled={isEksisterendeSoknaderLoading || !k9saksnummer}
                     >
                         <FormattedMessage id="ident.knapp.nyregistrering" />
                     </Button>

--- a/src/app/søknader/pleiepenger-livets-sluttfase/state/actions/EksisterendePLSSoknaderActions.ts
+++ b/src/app/søknader/pleiepenger-livets-sluttfase/state/actions/EksisterendePLSSoknaderActions.ts
@@ -1,6 +1,7 @@
 import { ApiPath } from 'app/apiConfig';
 import { IError } from 'app/models/types';
 import { convertResponseToError, get, post } from 'app/utils';
+import { createManglerK9saksnummerError, normalizeK9saksnummer } from 'app/utils/k9saksnummerUtils';
 
 import { IOpprettSoknad } from '../../../../models/types/RequestBodies';
 import { EksisterendePLSSoknaderActionKeys } from '../../types/EksisterendePLSSoknaderActionKeys';
@@ -188,11 +189,17 @@ export function createPLSSoknad(
     return (dispatch: any) => {
         dispatch(createPLSSoknadRequestAction());
 
+        const resolvedK9saksnummer = normalizeK9saksnummer(k9saksnummer);
+        if (!resolvedK9saksnummer) {
+            dispatch(createPLSSoknadErrorAction(createManglerK9saksnummerError()));
+            return;
+        }
+
         const requestBody: IOpprettSoknad = {
             journalpostId: journalpostid,
             norskIdent: søkerId,
             pleietrengendeIdent,
-            k9saksnummer,
+            k9saksnummer: resolvedK9saksnummer,
         };
 
         post(ApiPath.PLS_SOKNAD_CREATE, undefined, undefined, requestBody, (response, soknad) => {

--- a/src/app/søknader/pleiepenger/containers/PSBPunchForm.tsx
+++ b/src/app/søknader/pleiepenger/containers/PSBPunchForm.tsx
@@ -27,6 +27,7 @@ import {
     validerSoknadResetAction,
 } from 'app/state/actions';
 import intlHelper from 'app/utils/intlUtils';
+import { resolveK9saksnummer } from 'app/utils/k9saksnummerUtils';
 import {
     filtrerPerioderVedEndringAvSoknadsperiode,
     harSoknadsperioderBlittEndretEllerSlettet,
@@ -168,6 +169,8 @@ type IPunchFormProps = IPunchFormComponentProps &
     IPunchFormDispatchProps;
 
 export class PunchFormComponent extends React.Component<IPunchFormProps, IPunchFormComponentState> {
+    private harHentetPerioder = false;
+
     private initialPeriode: IPeriode = { fom: '', tom: '' };
 
     private initialArbeidstaker = new Arbeidstaker({
@@ -249,14 +252,7 @@ export class PunchFormComponent extends React.Component<IPunchFormProps, IPunchF
             return { feilmeldingStier: updatedFeilmeldingStier }; // Update state with the modified Set
         });
 
-        // henter Søker og Pleietrengende identer fra jp etter sideoppdatering, fordi identState kan være tom
-        const søkerId = this.props.identState.søkerId || this.props.fellesState.journalpost?.norskIdent;
-        const pleietrengendeId =
-            this.props.identState.pleietrengendeId || this.props.fellesState.journalpost?.sak?.pleietrengendeIdent;
-        const saksnummer = this.props.fellesState.journalpost?.sak?.fagsakId;
-        if (søkerId && pleietrengendeId && saksnummer) {
-            this.props.hentPerioder(søkerId, pleietrengendeId, saksnummer);
-        }
+        this.hentPerioderHvisMulig();
     }
 
     componentDidUpdate(prevProps: IPunchFormProps) {
@@ -269,6 +265,7 @@ export class PunchFormComponent extends React.Component<IPunchFormProps, IPunchF
 
         // this.props.updateJournalposter(this.state.soknad.journalposter);
         if (soknad && !this.state.isFetched) {
+            this.hentPerioderHvisMulig(soknad);
             this.setState({
                 soknad: new PSBSoknad(punchFormState.soknad as IPSBSoknad),
                 isFetched: true,
@@ -278,6 +275,26 @@ export class PunchFormComponent extends React.Component<IPunchFormProps, IPunchF
             if (!soknad.barn || !soknad.barn.norskIdent || soknad.barn.norskIdent === '') {
                 this.updateSoknad({ barn: { norskIdent: this.props.identState.pleietrengendeId || '' } });
             }
+        }
+    }
+
+    private hentPerioderHvisMulig(soknad?: Partial<IPSBSoknad>) {
+        if (this.harHentetPerioder) {
+            return;
+        }
+
+        // henter Søker og Pleietrengende identer fra jp eller søknad etter sideoppdatering, fordi identState kan være tom
+        const søkerId =
+            this.props.identState.søkerId || this.props.fellesState.journalpost?.norskIdent || soknad?.soekerId;
+        const pleietrengendeId =
+            this.props.identState.pleietrengendeId ||
+            this.props.fellesState.journalpost?.sak?.pleietrengendeIdent ||
+            soknad?.barn?.norskIdent;
+        const saksnummer = resolveK9saksnummer(undefined, this.props.fellesState.journalpost, soknad);
+
+        if (søkerId && pleietrengendeId && saksnummer) {
+            this.harHentetPerioder = true;
+            this.props.hentPerioder(søkerId, pleietrengendeId, saksnummer);
         }
     }
 

--- a/src/app/søknader/pleiepenger/containers/RegistreringsValg/PSBRegistreringsValg.tsx
+++ b/src/app/søknader/pleiepenger/containers/RegistreringsValg/PSBRegistreringsValg.tsx
@@ -8,6 +8,7 @@ import { ROUTES } from 'app/constants/routes';
 import { IdentRules } from 'app/validation';
 import { RootStateType } from 'app/state/RootState';
 import { createSoknad, findEksisterendeSoknader, resetSoknadidAction } from 'app/state/actions';
+import { manglerK9saksnummerMessage, resolveK9saksnummer } from 'app/utils/k9saksnummerUtils';
 import { hentAlleJournalposterForIdent as hentAlleJournalposterPerIdentAction } from 'app/state/actions/JournalposterPerIdentActions';
 import EksisterendeSoknader from '../EksisterendePSBSoknader';
 import { Dispatch } from 'redux';
@@ -36,9 +37,10 @@ export const PSBRegistreringsValg: React.FC<Props> = ({ journalpostid }: Props) 
     const getAlleJournalposter = (norskIdent: string) => dispatch(hentAlleJournalposterPerIdentAction(norskIdent));
 
     const fordelingState = useSelector((state: RootStateType) => state.fordelingState);
+    const journalpost = useSelector((state: RootStateType) => state.felles.journalpost);
     const eksisterendeSoknaderState = useSelector((state: RootStateType) => state.eksisterendeSoknaderState);
     const identState = useSelector((state: RootStateType) => state.identState);
-    const k9saksnummer = fordelingState.fagsak?.fagsakId;
+    const k9saksnummer = resolveK9saksnummer(fordelingState, journalpost);
 
     const { søkerId, pleietrengendeId } = identState;
     const {
@@ -67,10 +69,10 @@ export const PSBRegistreringsValg: React.FC<Props> = ({ journalpostid }: Props) 
 
     // Starte søknad automatisk hvis ingen søknader finnes
     useEffect(() => {
-        if (!isEksisterendeSoknaderLoading && søknader?.length === 0) {
+        if (!isEksisterendeSoknaderLoading && søknader?.length === 0 && k9saksnummer) {
             createNewSoknad(journalpostid, søkerId, pleietrengendeId, k9saksnummer);
         }
-    }, [isEksisterendeSoknaderLoading, søknader]);
+    }, [isEksisterendeSoknaderLoading, journalpostid, k9saksnummer, pleietrengendeId, søkerId, søknader]);
 
     useEffect(() => {
         if (isSoknadCreated && soknadid) {
@@ -103,6 +105,11 @@ export const PSBRegistreringsValg: React.FC<Props> = ({ journalpostid }: Props) 
                 fagsakId={k9saksnummer || ''}
                 kanStarteNyRegistrering={kanStarteNyRegistrering()}
             />
+            {!k9saksnummer && (
+                <Alert size="small" variant="warning">
+                    {manglerK9saksnummerMessage}
+                </Alert>
+            )}
             <div className="knapperad">
                 <Button
                     variant="secondary"
@@ -118,7 +125,7 @@ export const PSBRegistreringsValg: React.FC<Props> = ({ journalpostid }: Props) 
                         onClick={() => createNewSoknad(journalpostid, søkerId, pleietrengendeId, k9saksnummer)}
                         className="knapp2"
                         size="small"
-                        disabled={isEksisterendeSoknaderLoading}
+                        disabled={isEksisterendeSoknaderLoading || !k9saksnummer}
                     >
                         <FormattedMessage id="ident.knapp.nyregistrering" />
                     </Button>

--- a/src/app/utils/k9saksnummerUtils.spec.ts
+++ b/src/app/utils/k9saksnummerUtils.spec.ts
@@ -18,15 +18,28 @@ describe('k9saksnummerUtils', () => {
             expect(
                 resolveK9saksnummer(
                     { fagsak: { fagsakId: 'FORDELING', sakstype: 'PSB' } as any },
-                    { sak: { fagsakId: 'JOURNALPOST', sakstype: 'PSB' } as any },
+                    { erFerdigstilt: false, sak: { fagsakId: 'JOURNALPOST', sakstype: 'PSB' } as any },
                 ),
             ).toBe('FORDELING');
+        });
+
+        it('uses journalpost sak before fordeling fagsak for ferdigstilt journalpost', () => {
+            expect(
+                resolveK9saksnummer(
+                    { fagsak: { fagsakId: 'FORDELING', sakstype: 'PSB' } as any },
+                    { erFerdigstilt: true, sak: { fagsakId: 'JOURNALPOST', sakstype: 'PSB' } as any },
+                ),
+            ).toBe('JOURNALPOST');
         });
 
         it('falls back to journalpost sak when fordeling fagsak is missing', () => {
             expect(resolveK9saksnummer(undefined, { sak: { fagsakId: 'JOURNALPOST', sakstype: 'PSB' } as any })).toBe(
                 'JOURNALPOST',
             );
+        });
+
+        it('falls back to søknad k9saksnummer when state sources are missing', () => {
+            expect(resolveK9saksnummer(undefined, undefined, { k9saksnummer: ' SOKNAD ' })).toBe('SOKNAD');
         });
 
         it('ignores blank values when resolving', () => {

--- a/src/app/utils/k9saksnummerUtils.spec.ts
+++ b/src/app/utils/k9saksnummerUtils.spec.ts
@@ -1,0 +1,41 @@
+import { normalizeK9saksnummer, resolveK9saksnummer } from './k9saksnummerUtils';
+
+describe('k9saksnummerUtils', () => {
+    describe('normalizeK9saksnummer', () => {
+        it('returns trimmed saksnummer', () => {
+            expect(normalizeK9saksnummer('  ABC123  ')).toBe('ABC123');
+        });
+
+        it('returns undefined for blank values', () => {
+            expect(normalizeK9saksnummer('   ')).toBeUndefined();
+            expect(normalizeK9saksnummer(undefined)).toBeUndefined();
+            expect(normalizeK9saksnummer(null)).toBeUndefined();
+        });
+    });
+
+    describe('resolveK9saksnummer', () => {
+        it('uses fordeling fagsak before journalpost sak', () => {
+            expect(
+                resolveK9saksnummer(
+                    { fagsak: { fagsakId: 'FORDELING', sakstype: 'PSB' } as any },
+                    { sak: { fagsakId: 'JOURNALPOST', sakstype: 'PSB' } as any },
+                ),
+            ).toBe('FORDELING');
+        });
+
+        it('falls back to journalpost sak when fordeling fagsak is missing', () => {
+            expect(resolveK9saksnummer(undefined, { sak: { fagsakId: 'JOURNALPOST', sakstype: 'PSB' } as any })).toBe(
+                'JOURNALPOST',
+            );
+        });
+
+        it('ignores blank values when resolving', () => {
+            expect(
+                resolveK9saksnummer(
+                    { fagsak: { fagsakId: '   ', sakstype: 'PSB' } as any },
+                    { sak: { fagsakId: ' JOURNALPOST ', sakstype: 'PSB' } as any },
+                ),
+            ).toBe('JOURNALPOST');
+        });
+    });
+});

--- a/src/app/utils/k9saksnummerUtils.spec.ts
+++ b/src/app/utils/k9saksnummerUtils.spec.ts
@@ -1,4 +1,28 @@
+import { DokumenttypeForkortelse } from 'app/models/enums';
+import Fagsak from 'app/types/Fagsak';
+
 import { normalizeK9saksnummer, resolveK9saksnummer } from './k9saksnummerUtils';
+
+type FordelingK9saksnummerSource = NonNullable<Parameters<typeof resolveK9saksnummer>[0]>;
+type JournalpostK9saksnummerSource = NonNullable<Parameters<typeof resolveK9saksnummer>[1]>;
+
+const createFagsak = (fagsakId: string): Fagsak => ({
+    fagsakId,
+    sakstype: DokumenttypeForkortelse.PSB,
+    gyldigPeriode: { fom: '', tom: '' },
+});
+
+const createFordelingSource = (fagsakId: string): FordelingK9saksnummerSource => ({
+    fagsak: createFagsak(fagsakId),
+});
+
+const createJournalpostSource = (
+    fagsakId: string,
+    erFerdigstilt?: boolean,
+): JournalpostK9saksnummerSource => ({
+    erFerdigstilt,
+    sak: createFagsak(fagsakId),
+});
 
 describe('k9saksnummerUtils', () => {
     describe('normalizeK9saksnummer', () => {
@@ -17,8 +41,8 @@ describe('k9saksnummerUtils', () => {
         it('uses fordeling fagsak before journalpost sak', () => {
             expect(
                 resolveK9saksnummer(
-                    { fagsak: { fagsakId: 'FORDELING', sakstype: 'PSB' } as any },
-                    { erFerdigstilt: false, sak: { fagsakId: 'JOURNALPOST', sakstype: 'PSB' } as any },
+                    createFordelingSource('FORDELING'),
+                    createJournalpostSource('JOURNALPOST', false),
                 ),
             ).toBe('FORDELING');
         });
@@ -26,16 +50,14 @@ describe('k9saksnummerUtils', () => {
         it('uses journalpost sak before fordeling fagsak for ferdigstilt journalpost', () => {
             expect(
                 resolveK9saksnummer(
-                    { fagsak: { fagsakId: 'FORDELING', sakstype: 'PSB' } as any },
-                    { erFerdigstilt: true, sak: { fagsakId: 'JOURNALPOST', sakstype: 'PSB' } as any },
+                    createFordelingSource('FORDELING'),
+                    createJournalpostSource('JOURNALPOST', true),
                 ),
             ).toBe('JOURNALPOST');
         });
 
         it('falls back to journalpost sak when fordeling fagsak is missing', () => {
-            expect(resolveK9saksnummer(undefined, { sak: { fagsakId: 'JOURNALPOST', sakstype: 'PSB' } as any })).toBe(
-                'JOURNALPOST',
-            );
+            expect(resolveK9saksnummer(undefined, createJournalpostSource('JOURNALPOST'))).toBe('JOURNALPOST');
         });
 
         it('falls back to søknad k9saksnummer when state sources are missing', () => {
@@ -45,8 +67,8 @@ describe('k9saksnummerUtils', () => {
         it('ignores blank values when resolving', () => {
             expect(
                 resolveK9saksnummer(
-                    { fagsak: { fagsakId: '   ', sakstype: 'PSB' } as any },
-                    { sak: { fagsakId: ' JOURNALPOST ', sakstype: 'PSB' } as any },
+                    createFordelingSource('   '),
+                    createJournalpostSource(' JOURNALPOST '),
                 ),
             ).toBe('JOURNALPOST');
         });

--- a/src/app/utils/k9saksnummerUtils.ts
+++ b/src/app/utils/k9saksnummerUtils.ts
@@ -10,10 +10,19 @@ export const normalizeK9saksnummer = (k9saksnummer?: string | null): string | un
 
 export const resolveK9saksnummer = (
     fordelingState?: Pick<IFordelingState, 'fagsak'>,
-    journalpost?: Pick<IJournalpost, 'sak'>,
-): string | undefined =>
-    normalizeK9saksnummer(fordelingState?.fagsak?.fagsakId) ||
-    normalizeK9saksnummer(journalpost?.sak?.fagsakId);
+    journalpost?: Pick<IJournalpost, 'sak' | 'erFerdigstilt'>,
+    soknad?: { k9saksnummer?: string | null },
+): string | undefined => {
+    const fordelingK9saksnummer = normalizeK9saksnummer(fordelingState?.fagsak?.fagsakId);
+    const journalpostK9saksnummer = normalizeK9saksnummer(journalpost?.sak?.fagsakId);
+    const soknadK9saksnummer = normalizeK9saksnummer(soknad?.k9saksnummer);
+
+    if (journalpost?.erFerdigstilt) {
+        return journalpostK9saksnummer || soknadK9saksnummer || fordelingK9saksnummer;
+    }
+
+    return fordelingK9saksnummer || journalpostK9saksnummer || soknadK9saksnummer;
+};
 
 export const createManglerK9saksnummerError = (): IError => ({
     status: 400,

--- a/src/app/utils/k9saksnummerUtils.ts
+++ b/src/app/utils/k9saksnummerUtils.ts
@@ -1,0 +1,22 @@
+import { IFordelingState, IJournalpost } from 'app/models/types';
+import { IError } from 'app/models/types/Error';
+
+export const manglerK9saksnummerMessage = 'Mangler saksnummer for opprettelse av søknad.';
+
+export const normalizeK9saksnummer = (k9saksnummer?: string | null): string | undefined => {
+    const normalized = k9saksnummer?.trim();
+    return normalized ? normalized : undefined;
+};
+
+export const resolveK9saksnummer = (
+    fordelingState?: Pick<IFordelingState, 'fagsak'>,
+    journalpost?: Pick<IJournalpost, 'sak'>,
+): string | undefined =>
+    normalizeK9saksnummer(fordelingState?.fagsak?.fagsakId) ||
+    normalizeK9saksnummer(journalpost?.sak?.fagsakId);
+
+export const createManglerK9saksnummerError = (): IError => ({
+    status: 400,
+    statusText: manglerK9saksnummerMessage,
+    message: manglerK9saksnummerMessage,
+});


### PR DESCRIPTION
### **Behov / Bakgrunn**

Noen create søknad-kall kunne bli sendt uten gyldig `k9saksnummer`. Det skjedde i flyter der journalposten ennå ikke var journalført, eller der frontend ikke hadde fått oppdatert fagsak i state før søknaden ble opprettet.

Backend forventer nå `k9saksnummer` i create requesten. Når feltet manglet eller var blankt, kunne backend ikke behandle requesten riktig.

### **Løsning**

- Krever gyldig `k9saksnummer` før create søknad-kall sendes.
- Leser `k9saksnummer` fra valgt eller reservert fagsak før journalføring.
- Prioriterer `journalpost.sak` når journalposten er ferdigstilt, siden den kan være ferskere etter journalføring.
- Bruker `søknad.k9saksnummer` som fallback inne i OLP og PSB punch ved reload.
- La til tester for resolver-logikken og oppdaterte changelog.

### **Andre endringer**

- OLP søknadstype beskriver nå `k9saksnummer` fra backendresponsen.
- PSB perioder hentes først når søker, pleietrengende og saksnummer kan løses fra journalpost eller søknad.
