### PR TITLE
Tydeliggjør README og lokalt utvikleroppsett

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ TLDR er å opprette en GitHub PAT med kun `read:packages`-tilgang, enable SSO, o
 
 ```yaml
 npmRegistries:
-  https://npm.pkg.github.com:
-    npmAlwaysAuth: true
-    npmAuthToken: <token>
+    https://npm.pkg.github.com:
+        npmAlwaysAuth: true
+        npmAuthToken: <token>
 ```
 
 Merk at dette _ikke_ skal sjekkes inn i versjonskontroll.
@@ -28,44 +28,27 @@ yarn install --immutable
 yarn dev
 ```
 
-## Lokal utvikling (innlogging & k9-punsj)
+## Lokal utvikling med backend
 
-1. `cd dev`
-2. `docker login ghcr.io -u x-access-token (GitHub personal access token med kun read-rettigheter som passord)`
-3. `docker-compose pull`
-4. `docker-compose up`
-5. Start opp klassen [K9PunsjApplicationWithMocks](https://github.com/navikt/k9-punsj/blob/master/app/src/test/kotlin/no/nav/k9punsj/K9PunsjApplicationWithMocks.kt) i [k9-punsj](https://github.com/navikt/k9-punsj)
-    - Om du får feil lignende `Process [/var/folders/***/embedded-pg/***/bin/initdb, -A, trust, -U, postgres, -D, /var/folders/h/***, -E, UTF-8] failed` følg løsning med å sette environment variabler beskrevet i [her](https://github.com/zonkyio/embedded-postgres/issues/11#issuecomment-533468269)
+Start Docker-tjenestene fra rot av repo:
 
-### Journalpostnumre for lokal utvikling
-
-Man kan taste inn hvilket nummer som helst som journalpostID. Noen journalpostnummer har egne responser.
-
-```text
-- 200: Gir journalpost med PDF dokument knyttet til PSB-sak
-- 404: Finnes ikke
-- 403: Ikke tilgang
-- 409: IkkeStøttet
-- 500: AbacError
-- 420: Journalpost knyttet til OLP-sak
-- 7523521: Ferdigstilt med saksnummer
-- 463687943: Finnes informasjon i Infotrygd.
-- 45537868838: Journalpost støttes ikke.
+```bash
+yarn docker-up
 ```
+
+Start deretter [K9PunsjApplicationWithMocks](https://github.com/navikt/k9-punsj/blob/master/app/src/test/kotlin/no/nav/k9punsj/K9PunsjApplicationWithMocks.kt) i [k9-punsj](https://github.com/navikt/k9-punsj).
+
+Fullstendig oppsett med docker-innlogging, stopp-kommando og journalpostnumre for lokale mock-responser finner du i [dev/README.md](dev/README.md).
 
 ## UI-utvikling uten backend
 
-Når du bare trenger frontend og mockdata, kan du jobbe uten å starte backend-repoet.
+Når du bare trenger frontend og mockdata, kan du jobbe uten å starte backend-repoet:
 
 ```bash
 yarn test:e2eUI
 ```
 
-Starter appen lokalt på `http://localhost:8080` med MSW-baserte testmocker og uten proxy til lokal backend, og åpner Cypress UI slik at du kan kjøre eller debugge scenarier visuelt mens du jobber i frontend.
-
-Mockdata for denne modusen ligger hovedsakelig i [src/mocks/mockHandlersTest.ts](src/mocks/mockHandlersTest.ts) og [cypress/fixtures](cypress/fixtures).
-
-I mockmodus finnes det egne journalpost-scenarier for blant annet `300`, `301`, `302`, `303`, `304`, `305`, `310`, `311`, `312`, `314` og `320`. Disse er koblet til egne fixtures i testoppsettet. `200` og andre journalpostnummer som ikke er listet her går som hovedregel mot standard mockdata, mens `206` brukes som et eget `403`-scenario.
+Starter appen på `http://localhost:8080` med MSW-baserte testmocker og åpner Cypress UI for visuell debugging. Mockdata og scenarioliste ligger i [dev/README.md](dev/README.md).
 
 ## Nyttige kommandoer
 
@@ -111,7 +94,7 @@ Interne henvendelser kan sendes via Slack i kanalen #sif_saksbehandling.
 
 ## Kode generert av GitHub Copilot
 
-Dette repoet bruker GitHub Copilot til å generere kode.
+Dette repoet bruker GitHub Copilot aktivt til å generere og forbedre kode.
 
 ## Copilot og agenter
 
@@ -127,4 +110,3 @@ Repoet inneholder konfigurasjon for Copilot og AI-agenter.
 - Lokal VS Code MCP-konfigurasjon ligger i [`.vscode/mcp.json`](.vscode/mcp.json).
 
 ![k9-punsj-frontend](logo.png)
-![7aa5dd7e-33d3-49b4-b23b-ab2b637fbe1a](https://github.com/navikt/k9-punsj-frontend/assets/25080417/4dab2369-6493-4abb-a613-a5f409ecfd57)

--- a/copilot-tasks/readme-boundaries-refresh.md
+++ b/copilot-tasks/readme-boundaries-refresh.md
@@ -1,0 +1,108 @@
+# Copilot task
+
+## Task
+
+- Title: Refresh README boundaries and split deeper setup into the right docs
+- Branch: `docs/readme-boundaries-refresh`
+- Suggested agent: `@k9-punsj-front-forfatter-agent`
+- Prompt language: `Norwegian`
+
+## Goal
+
+- Gjør root `README.md` til en tydelig startside for repoet i stedet for en blanding av startside, intern dev note og workflow note.
+- Flytt eller forkort dypere local dev-detaljer til riktige dokumenter der det er naturlig, uten å miste nyttig informasjon.
+
+## Context
+
+- `README.md` ble forbedret i mars 2026 og er ikke lenger klart stale.
+- Det som gjenstår er hovedsakelig boundary-arbeid, ikke en stor opprydding fra bunnen av.
+- Root README blander fortsatt flere roller:
+    - quick start
+    - lokal backend og auth-oppsett
+    - mock-basert frontendflyt
+    - deploy-flyt
+    - Copilot og agent-peker
+- Repoet har en tom `dev/README.md`, så root README bærer i dag mer operational context enn ønskelig.
+- Teamet ønsker fortsatt å beholde et tydelig utsagn om at repoet bruker GitHub Copilot til å generere kode. Dette punktet skal ikke fjernes, men kan omformuleres hvis det gir bedre kvalitet i README.
+
+## Scope
+
+- Allowed files or areas:
+    - `README.md`
+    - `dev/README.md`
+    - `docs/copilot-workflow.md` only if small wording or link alignment is needed
+    - `docs/CHANGELOG.md` if the documentation change merits a short note
+    - `copilot-tasks/readme-boundaries-refresh.md` for `Plan`, `Progress notes`, and `Outcome`
+- Out of scope:
+    - `package.json`
+    - `.github/workflows/**`
+    - scripts, build, deploy behavior, or CI behavior
+    - broader documentation restructuring outside the files listed above
+    - changes to `AGENTS.md`, local `docsLocal/`, or repo prompts and agents
+
+## Relevant files
+
+- `README.md`
+- `dev/README.md`
+- `docs/copilot-workflow.md`
+- `package.json`
+- `.github/workflows/valid-pull-request.yml`
+- `.github/workflows/test.yml`
+- `.github/workflows/lint.yml`
+- `.github/workflows/cypress-tester.yml`
+- `.github/workflows/deploy-preprod-gcp.yml`
+- `.github/workflows/build-and-deploy-gcp.yml`
+
+## Constraints
+
+- Keep the change scoped to documentation files in this task.
+- Reuse existing repo wording and structure before inventing a new documentation system.
+- Follow `AGENTS.md`, `.github/copilot-instructions.md`, and any relevant file specific instructions in `.github/instructions/`.
+- Do not change runtime behavior, scripts, workflows, or commands. Only document them more clearly.
+- Treat root `README.md` as a contributor-facing entrypoint, not a full internal wiki.
+- If deeper local setup details still matter, prefer moving them into `dev/README.md` rather than keeping everything in root README.
+- Keep the GitHub Copilot disclosure in root README.
+    - It may be rephrased for clarity and tone.
+    - It must remain clear that the repo uses GitHub Copilot to generate code.
+- Do not remove deploy information entirely unless you replace it with a clearer short reference in the allowed documentation scope.
+- Prefer repo scripts such as `yarn docker-up` and `yarn docker-down` over raw command sequences when documenting the normal path.
+- Keep Norwegian wording natural and concise.
+- Avoid turning README into a long handover note.
+
+## Validation
+
+- Commands to run:
+    - `yarn lint README.md dev/README.md docs/copilot-workflow.md` is not applicable, because these are Markdown files and the repo does not expose a Markdown lint task
+    - `sed -n '1,260p' README.md`
+    - `sed -n '1,220p' dev/README.md`
+    - `rg -n "\"(dev|lint|test|test:e2e|test:e2eUI|storybook|build-storybook|docker-up|docker-down|lint:css)\"" package.json`
+    - `rg -n "node-version:|yarn install|yarn test|yarn lint|cypress|start:e2e|deploy" .github/workflows`
+- If you choose not to update `dev/README.md`, explain why in `Outcome`.
+
+## Plan
+
+1. Flytt "Lokal utvikling (innlogging & k9-punsj)" med docker-oppsett og journalpost-tabeller til `dev/README.md`.
+2. Erstatt rå `docker-compose`-kommandoer i README med `yarn docker-up` / `yarn docker-down` der relevant.
+3. Forkort avsnittet "UI-utvikling uten backend" i rot-README – behold kommandoen og en kort forklaring, men fjern den detaljerte listen over mock-scenarionumre til `dev/README.md`.
+4. Hold rot-README som tydelig contributor-entrypoint: intro, komme i gang, korte pekere til `dev/README.md`, kommandoer, tester, deploy, henvendelser, Copilot-disclosure og agentreferanser.
+5. Oppdater `docs/CHANGELOG.md` med en kort linje under `Unreleased`.
+
+## Progress notes
+
+- Analysert nåværende README mot `package.json` og eksisterende docs-struktur.
+- `dev/README.md` var tom – skrevet fra bunnen av med docker-oppsett og journalpost-tabeller.
+- Rot-README forkortet: rå `docker-compose`-kommandoer og journalpost-lister fjernet, erstattet med `yarn docker-up`/`yarn docker-down` og peker til `dev/README.md`.
+
+## Outcome
+
+**Endrede filer:**
+
+- `README.md` – kortere og tydeligere entrypoint; operasjonelle detaljer erstattet med pekere til `dev/README.md`; Copilot-disclosure omformulert
+- `dev/README.md` – ny innhold: docker-oppsett, journalpost-tabeller for backend-mocker og MSW-mocker
+- `docs/CHANGELOG.md` – kort linje under nyeste oppføring
+
+**Ikke endret:** `docs/copilot-workflow.md` – ingen small wording eller link-justering var nødvendig.
+
+**Validering:** `sed -n '1,260p' README.md` og `sed -n '1,220p' dev/README.md` viser korrekt struktur. Ingen runtime-atferd, scripts eller workflows er endret.
+
+**Gjenstående risiko:** ingen.

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,81 @@
+# Lokal utvikling
+
+Detaljer for å kjøre opp k9-punsj-frontend lokalt med backend og mock-data.
+
+## Lokal utvikling med backend
+
+### Forutsetninger
+
+Logg inn mot GitHub Container Registry med en GitHub PAT med `read:packages`-tilgang:
+
+```bash
+docker login ghcr.io -u x-access-token
+# Passord: GitHub personal access token med kun read:packages-tilgang
+```
+
+### Start Docker-tjenester
+
+Fra rot av repo:
+
+```bash
+yarn docker-up
+```
+
+Tilsvarer `docker-compose -f dev/docker-compose.yml up -d`.
+
+For å stoppe:
+
+```bash
+yarn docker-down
+```
+
+### Start backend
+
+Start klassen [K9PunsjApplicationWithMocks](https://github.com/navikt/k9-punsj/blob/master/app/src/test/kotlin/no/nav/k9punsj/K9PunsjApplicationWithMocks.kt) i [k9-punsj](https://github.com/navikt/k9-punsj).
+
+> **Merk:** Får du feil lignende `Process [.../initdb, ...] failed`, følg løsningen med environment-variabler beskrevet [her](https://github.com/zonkyio/embedded-postgres/issues/11#issuecomment-533468269).
+
+### Journalpostnumre for lokal utvikling (backend-mocker)
+
+Noen journalpostnummer gir egne responser:
+
+| Nummer        | Respons                                 |
+| ------------- | --------------------------------------- |
+| `200`         | Journalpost med PDF knyttet til PSB-sak |
+| `404`         | Finnes ikke                             |
+| `403`         | Ikke tilgang                            |
+| `409`         | IkkeStøttet                             |
+| `500`         | AbacError                               |
+| `420`         | Journalpost knyttet til OLP-sak         |
+| `7523521`     | Ferdigstilt med saksnummer              |
+| `463687943`   | Finnes informasjon i Infotrygd          |
+| `45537868838` | Journalpost støttes ikke                |
+
+Andre nummer fungerer mot standard mock-responser.
+
+## UI-utvikling uten backend (MSW-mocker)
+
+For ren frontend-utvikling med MSW-baserte mocker, se `yarn test:e2eUI` i [rot-README](../README.md).
+
+Mockdata ligger i [src/mocks/mockHandlersTest.ts](../src/mocks/mockHandlersTest.ts) og [cypress/fixtures](../cypress/fixtures).
+
+### Journalpost-scenarier i mockmodus
+
+| Nummer | Sakstype       | Status       | Scenario                                                                                                      |
+| ------ | -------------- | ------------ | ------------------------------------------------------------------------------------------------------------- |
+| `300`  | PSB            | MOTTATT      | Papirsøknad, ikke ferdigstilt, kan sendes inn                                                                 |
+| `301`  | PPN (PILS)     | MOTTATT      | Papirsøknad, ikke ferdigstilt, kan sendes inn                                                                 |
+| `302`  | OMP_KS         | MOTTATT      | Papirsøknad, ikke ferdigstilt, kan sendes inn                                                                 |
+| `303`  | OMP_AO         | MOTTATT      | Papirsøknad, ikke ferdigstilt, kan sendes inn                                                                 |
+| `304`  | OMP_MA         | MOTTATT      | Papirsøknad, ikke ferdigstilt, kan sendes inn                                                                 |
+| `305`  | OMP            | MOTTATT      | Papirsøknad, ikke ferdigstilt, kan sendes inn                                                                 |
+| `310`  | Ukjent (null)  | MOTTATT      | Ferdigstilt, kan **ikke** sendes inn, sakstype mangler                                                        |
+| `311`  | PPN (PILS)     | JOURNALFOERT | Ferdigstilt, kan **ikke** sendes inn, innsendingtype UKJENT                                                   |
+| `312`  | PSB            | JOURNALFOERT | Ferdigstilt, kan sendes inn, reservert saksnummer med fagsakId                                                |
+| `314`  | OMP            | MOTTATT      | Ferdigstilt, kan sendes inn, reservert saksnummer, behandlingsår 2022, barnliste                              |
+| `315`  | Uavklart (`-`) | MOTTATT      | Ferdigstilt, kan **ikke** sendes inn, innsendingtype UKJENT, sakstype uavklart                                |
+| `320`  | PSB            | JOURNALFOERT | Ferdigstilt, kan **ikke** sendes inn, kan ikke opprette journalføringsoppgave, har fagsakId og pleietrengende |
+| `206`  | –              | –            | HTTP 403 Forbidden                                                                                            |
+| `200`  | –              | –            | Standard mock-data (journalpost.json), journalpostId settes dynamisk                                          |
+
+Andre nummer ikke listet ovenfor går mot standard mockdata.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Kort logg over merkbare repo-endringer og oppsettendringer.
 
+### README-grenser oppdatert (2026-05-06)
+
+- Rot-README er gjort kortere og tydeligere som contributor-entrypoint.
+- Detaljert lokal dev-oppsett (docker-oppsett, journalpost-tabeller, mock-scenarioliste) er flyttet til `dev/README.md`.
+- Mock-scenariotabellen i `dev/README.md` utvidet med spesifikke sakstyper og scenario-beskrivelser fra fixtures.
+- PAT-scope-ordlyd harmonisert til `read:packages` i begge filer.
+- Overflødig ekstern bilde-URL fjernet fra rot-README; `logo.png` beholdt.
+
 ### K9 saksnummer for create requests (2026-05-04)
 
 - Stopper create søknad-kall når `k9saksnummer` mangler eller er blankt, i stedet for å sende en request som backend ikke kan decode.


### PR DESCRIPTION
### **Behov / Bakgrunn**

README i rot av repoet hadde blitt en blanding av oppstart, lokal backend-kjøring, mock-scenarier, deploy-flyt og Copilot-informasjon. Det gjorde den mindre tydelig som første inngang for utviklere.

Det var behov for å rydde opp i grensene mellom root README og mer detaljert lokal utviklerdokumentasjon, uten å miste nyttig informasjon.

### **Løsning**

Root `README.md` er kortet ned og tydeliggjort som contributor-facing entrypoint.

Mer detaljert lokal utviklerinformasjon er flyttet til `dev/README.md`, inkludert docker-oppsett, backend-mocker og journalpost-scenarier for mockmodus.

README bruker nå repo-scripts som `yarn docker-up` og `yarn docker-down` i stedet for rå lokale docker-kommandoer. GitHub Copilot-opplysningen er beholdt, men formuleringen er strammet litt inn. Ekstra image-støy i README er redusert.

### **Andre endringer**

Det er lagt til en kort changelog-oppføring i `docs/CHANGELOG.md`.
Ingen runtime, workflow, script eller deploy-atferd er endret.

### **Skjermbilder** (hvis relevant)

Ikke relevant.
