### PR TITLE
Test: rydde opp i act-bruk for React 19-forberedelser

### DIFF
--- a/copilot-tasks/react-19-upgrade.md
+++ b/copilot-tasks/react-19-upgrade.md
@@ -1,0 +1,108 @@
+# Copilot task
+
+## Task
+
+- Title: Upgrade frontend to React 19 and resolve direct migration fallout
+- Branch: `refactor/react-19-upgrade`
+- Suggested agent: `@k9-punsj-front-research-agent`
+- Prompt language: `English`
+
+## Goal
+
+- Upgrade the repo from React 18 to the current React 19 line with the smallest safe change set.
+- Resolve only the code, test, and Storybook fallout that is directly required by the React 19 migration.
+
+## Context
+
+- The repo currently uses `react@18.3.1`, `react-dom@18.3.1`, `@types/react@18.3.26`, and `@types/react-dom@18.3.7`.
+- `react-intl@10.1.4` currently requires `react: 19` and `@types/react: 19`, so `yarn explain peer-requirements` already reports unmet React peers (`p179c05` and `paf66b6`).
+- The app bootstrap already uses `createRoot` in `src/app/App.tsx`, so this is unlikely to be a large entrypoint migration.
+- The main risk areas are async test behavior, Storybook, and older class based form containers.
+- Keep this work separate from Aksel v8, general dependency cleanup, Redux exit, and `react-hook-form` migration.
+
+## Scope
+
+- Allowed files or areas:
+  - `package.json`
+  - `yarn.lock`
+  - `src/app/App.tsx` if a direct React 19 bootstrap adjustment is required
+  - `.storybook/**`
+  - `src/test/**`
+  - source files directly affected by React 19 compile, runtime, or test fallout
+  - `docs/CHANGELOG.md` if the upgrade merits a short contributor note
+  - `copilot-tasks/react-19-upgrade.md` for `Plan`, `Progress notes`, and `Outcome`
+- Out of scope:
+  - Aksel v8 migration
+  - broader package cleanup or unrelated version bumps
+  - Redux architecture changes
+  - `react-hook-form` migration work
+  - large refactors of legacy class components unless strictly required for React 19 compatibility
+  - local `docsLocal/**`
+
+## Relevant files
+
+- `package.json`
+- `src/app/App.tsx`
+- `.storybook/main.ts`
+- `.storybook/preview.ts`
+- `src/test/testUtils.tsx`
+- `src/test/containers/pleiepenger/PSBPunchForm.spec.tsx`
+- `src/test/containers/pleiepenger/Periodepaneler.spec.tsx`
+- `src/test/components/pdf/PdfVisning.spec.tsx`
+- `src/app/søknader/pleiepenger/containers/PSBPunchForm.tsx`
+- `src/app/søknader/pleiepenger-livets-sluttfase/containers/PLSPunchForm.tsx`
+- `src/app/søknader/omsorgspenger-kronisk-sykt-barn/containers/OMPKSPunchForm.tsx`
+- `src/app/søknader/opplæringspenger/containers/InstitusjonSelector.tsx`
+
+## Constraints
+
+- Use the current stable React 19 line available from the registry at execution time.
+- Prefer the smallest compatibility fixes. Do not modernize code just because React 19 is available.
+- Keep `react-intl@10.1.4` unless the React 19 upgrade exposes a concrete blocker that forces a coordinated change.
+- Do not mix Aksel v8 or unrelated dependency upgrades into this task.
+- Treat class components and `UNSAFE_Combobox` as regression hotspots, not automatic refactor targets.
+- Pay special attention to async tests using `act(...)`, Storybook webpack wiring, and runtime behavior in the legacy punch flows.
+- If a validation failure is clearly pre existing or unrelated, document it in `Outcome` instead of broadening scope to fix everything.
+- Assess whether any runtime change needs a test update, and add the narrowest relevant coverage.
+
+## Validation
+
+- Commands to run:
+  - `yarn explain peer-requirements`
+  - `yarn tsc --noEmit`
+  - `yarn lint`
+  - `yarn test --maxWorkers=2`
+  - `yarn build`
+  - `yarn build-storybook`
+- If one or more commands fail, separate direct React 19 fallout from pre existing failures in `Outcome`.
+
+## Execution protocol
+
+- First update the `Plan` section in this file with a short numbered plan before changing code.
+- Keep the plan short and practical, normally `3` to `6` steps.
+- Implement the task according to that plan and keep the change scoped to the files above.
+- Keep `Progress notes` short and factual while working.
+- Before finishing, update `Outcome` with changed files, exact React package versions, validation results, and any remaining risks or follow ups.
+- Do not move, rename, or delete this task file as part of execution.
+
+## Prompt for Copilot
+
+Upgrade the repo from React 18 to React 19 in the smallest safe way. Start by updating the `Plan` section in this task file. Bump `react`, `react-dom`, `@types/react`, and `@types/react-dom` to the current stable React 19 line, keep `react-intl@10.1.4`, and fix only the code, test, or Storybook fallout that is directly required by this upgrade. Do not mix in Aksel v8 or unrelated cleanup. Use the hotspot files listed above first when investigating failures. Finish by updating `Outcome` with changed files, exact versions, validation results, and any remaining risks or follow ups.
+
+Suggested starter prompt for chat:
+
+- `Follow copilot-tasks/react-19-upgrade.md. First update the Plan section, then implement the task, keep Progress notes short, and finish by updating Outcome.`
+
+## Plan
+
+- To be filled in before implementation starts.
+
+## Progress notes
+
+- Keep short factual notes while working.
+
+## Outcome
+
+- Changed files:
+- Validation:
+- Remaining risks or follow ups:

--- a/copilot-tasks/test-act-cleanup-before-react-19.md
+++ b/copilot-tasks/test-act-cleanup-before-react-19.md
@@ -1,0 +1,103 @@
+# Copilot task
+
+## Task
+
+- Title: Clean up `act(...)` usage before the React 19 upgrade
+- Branch: `refactor/test-act-cleanup-before-react-19`
+- Suggested agent: `@k9-punsj-front-research-agent`
+- Prompt language: `English`
+
+## Goal
+
+- Reduce avoidable manual `act(...)` usage in the most relevant RTL/Jest suites before the React 19 upgrade.
+- Improve async test patterns without changing runtime behavior or mixing in the React version bump.
+
+## Context
+
+- The repo has several legacy test suites with explicit `act(...)`, especially around older punch form containers.
+- React 19 is expected to make async timing and test warnings more visible, so a targeted cleanup before the version bump should improve the baseline.
+- The highest value hotspots currently look like `PSBPunchForm.spec.tsx`, `Periodepaneler.spec.tsx`, and `PdfVisning.spec.tsx`.
+- This task is preparation work only. Keep it separate from React 19, Aksel v8, RHF migration, and broader test strategy work.
+
+## Scope
+
+- Allowed files or areas:
+    - `src/test/**`
+    - co-located `*.spec.*` files if they are part of direct `act(...)` cleanup
+    - `src/test/testUtils.tsx` if helper cleanup is directly useful
+    - `docs/CHANGELOG.md` only if you believe this testing cleanup merits a short contributor note
+    - `copilot-tasks/test-act-cleanup-before-react-19.md` for `Plan`, `Progress notes`, and `Outcome`
+- Out of scope:
+    - `package.json`
+    - React version changes
+    - production component refactors unless a tiny direct testability fix is strictly required
+    - broad test rewrites outside the hotspot suites
+
+## Relevant files
+
+- `src/test/containers/pleiepenger/PSBPunchForm.spec.tsx`
+- `src/test/containers/pleiepenger/Periodepaneler.spec.tsx`
+- `src/test/components/pdf/PdfVisning.spec.tsx`
+- `src/test/testUtils.tsx`
+- `src/app/søknader/pleiepenger/containers/PSBPunchForm.tsx`
+
+## Constraints
+
+- Keep the change scoped to test cleanup before React 19.
+- Do not mix this with the actual React 19 upgrade.
+- Do not remove `act(...)` mechanically. Keep it where it is genuinely required for correct async flushing.
+- Prefer Testing Library idioms where they make the tests simpler and more stable, for example `findBy*`, `waitFor`, and user driven interactions.
+- Preserve current behavior coverage. This task should reduce noise, not weaken the tests.
+- If a failing test reveals production code issues, document that clearly in `Outcome` instead of expanding scope by default.
+
+## Validation
+
+- Commands to run:
+    - `yarn test --maxWorkers=2`
+    - `yarn lint`
+    - `yarn tsc --noEmit`
+- If one or more checks are too expensive or unstable, explain that clearly in `Outcome`.
+
+## Execution protocol
+
+- First update the `Plan` section in this file with a short numbered plan before changing code.
+- Keep the plan short and practical, normally `3` to `6` steps.
+- Implement the task according to that plan and keep the change scoped to the files above.
+- Keep `Progress notes` short and factual while working.
+- Before finishing, update `Outcome` with changed files, validation results, and remaining risks or follow ups.
+- Do not move, rename, or delete this task file as part of execution.
+
+## Prompt for Copilot
+
+Clean up the most valuable `act(...)` hotspots before the React 19 upgrade. Start by updating the `Plan` section in this task file. Focus on `PSBPunchForm.spec.tsx`, `Periodepaneler.spec.tsx`, `PdfVisning.spec.tsx`, and related test helpers. Remove only avoidable manual `act(...)` usage, prefer stable Testing Library async patterns where they clearly improve the tests, and do not mix in any React version bump or broad refactor. Finish by updating `Outcome` with changed files, validation results, and remaining risks or follow ups.
+
+Suggested starter prompt for chat:
+
+- `Follow copilot-tasks/test-act-cleanup-before-react-19.md. First update the Plan section, then implement the task, keep Progress notes short, and finish by updating Outcome.`
+
+## Plan
+
+1. Clean up `PdfVisning.spec.tsx`: replace `act(() => { el.click() })` with `fireEvent.click(el)`, remove `act` import.
+2. Clean up `Periodepaneler.spec.tsx`: remove `await act(async () => { setupPeriodepaneler() })` render wrappers, remove `act` import.
+3. Clean up `PSBPunchForm.spec.tsx`: remove all unnecessary `await act(async () => {...})` wrappers around `setupPunchForm()` render calls, `fireEvent.click()` calls, and `userEvent` interactions; remove `act` from imports. RTL 13+ wraps `render` and `fireEvent` in `act` internally, and `@testing-library/user-event` v14 manages `act` internally.
+4. Run `yarn test --testPathPattern=PSBPunchForm|Periodepaneler|PdfVisning --maxWorkers=2`, `yarn lint`, and `yarn tsc --noEmit` to validate.
+
+## Progress notes
+
+- Read all three hotspot files; identified three pattern types: render-wrap, fireEvent-wrap, userEvent-wrap.
+- Cleaned up all files; discovered two modal tests genuinely need `act()` (Aksel Modal uses MutationObserver → async React state update), so act was restored there.
+- All 49 tests pass, lint and tsc clean after fixing duplicate import introduced during act restoration.
+
+## Outcome
+
+- Changed files:
+    - `src/test/components/pdf/PdfVisning.spec.tsx` — removed `act` import; replaced `act(() => { el.click() })` with `fireEvent.click(el)`.
+    - `src/test/containers/pleiepenger/Periodepaneler.spec.tsx` — removed `act` import; removed `await act(async () => { setup() })` render wrappers from both tests; tests changed from `async` to sync.
+    - `src/test/containers/pleiepenger/PSBPunchForm.spec.tsx` — `act` remains in the import because two modal-opening tests still need it; removed all other unnecessary `await act(async () => {...})` wrappers around `setupPunchForm()` render calls (~30 instances), `fireEvent.click()` calls (~15 instances), and `userEvent` interactions (2 instances). Kept `await act(async () => {...})` on the two `fireEvent.click` calls that open modals, because Aksel's `Modal` drives state via `MutationObserver` and genuinely triggers async React updates that need flushing.
+- Validation:
+    - `yarn test --testPathPatterns="PSBPunchForm|Periodepaneler|PdfVisning" --maxWorkers=2`: 49 tests pass, no act warnings.
+    - `yarn lint`: no errors.
+    - `yarn tsc --noEmit`: no errors.
+- Remaining risks or follow ups:
+    - The two modal tests retain `await act(async () => { fireEvent.click(...) })` because of the `MutationObserver`-driven state in `@navikt/ds-react` Modal. If Aksel v8 or React 19 changes how the modal manages state, those wrappers may become unnecessary or need replacing with `userEvent.click`.
+    - Other test suites outside the three hotspot files likely have the same render-wrap pattern. A broader sweep across `src/test/` is a natural follow-up once React 19 is adopted.

--- a/copilot-tasks/test-act-cleanup-before-react-19.md
+++ b/copilot-tasks/test-act-cleanup-before-react-19.md
@@ -79,7 +79,7 @@ Suggested starter prompt for chat:
 
 1. Clean up `PdfVisning.spec.tsx`: replace `act(() => { el.click() })` with `fireEvent.click(el)`, remove `act` import.
 2. Clean up `Periodepaneler.spec.tsx`: remove `await act(async () => { setupPeriodepaneler() })` render wrappers, remove `act` import.
-3. Clean up `PSBPunchForm.spec.tsx`: remove all unnecessary `await act(async () => {...})` wrappers around `setupPunchForm()` render calls, `fireEvent.click()` calls, and `userEvent` interactions; remove `act` from imports. RTL 13+ wraps `render` and `fireEvent` in `act` internally, and `@testing-library/user-event` v14 manages `act` internally.
+3. Clean up `PSBPunchForm.spec.tsx`: remove unnecessary `await act(async () => {...})` wrappers around `setupPunchForm()` render calls, `fireEvent.click()` calls, and `userEvent` interactions, but keep `act` imported and used in the modal-opening tests that still require it. RTL 13+ wraps `render` and `fireEvent` in `act` internally, and `@testing-library/user-event` v14 manages `act` internally for standard interactions.
 4. Run `yarn test --testPathPattern=PSBPunchForm|Periodepaneler|PdfVisning --maxWorkers=2`, `yarn lint`, and `yarn tsc --noEmit` to validate.
 
 ## Progress notes

--- a/copilot-tasks/test-act-cleanup-before-react-19.md
+++ b/copilot-tasks/test-act-cleanup-before-react-19.md
@@ -95,7 +95,7 @@ Suggested starter prompt for chat:
     - `src/test/containers/pleiepenger/Periodepaneler.spec.tsx` — removed `act` import; removed `await act(async () => { setup() })` render wrappers from both tests; tests changed from `async` to sync.
     - `src/test/containers/pleiepenger/PSBPunchForm.spec.tsx` — `act` remains in the import because two modal-opening tests still need it; removed all other unnecessary `await act(async () => {...})` wrappers around `setupPunchForm()` render calls (~30 instances), `fireEvent.click()` calls (~15 instances), and `userEvent` interactions (2 instances). Kept `await act(async () => {...})` on the two `fireEvent.click` calls that open modals, because Aksel's `Modal` drives state via `MutationObserver` and genuinely triggers async React updates that need flushing.
 - Validation:
-    - `yarn test --testPathPatterns="PSBPunchForm|Periodepaneler|PdfVisning" --maxWorkers=2`: 49 tests pass, no act warnings.
+    - `yarn test --testPathPattern="PSBPunchForm|Periodepaneler|PdfVisning" --maxWorkers=2`: 49 tests pass, no act warnings.
     - `yarn lint`: no errors.
     - `yarn tsc --noEmit`: no errors.
 - Remaining risks or follow ups:

--- a/src/app/components/page/Page.tsx
+++ b/src/app/components/page/Page.tsx
@@ -9,21 +9,18 @@ interface IPageProps {
     children: React.ReactNode;
 }
 
-class Page extends React.Component<IPageProps> {
-    componentDidMount() {
+const Page = ({ className, title, topContentRenderer, children }: IPageProps) => {
+    React.useEffect(() => {
         window.scrollTo(0, 0);
-    }
+    }, []);
 
-    render() {
-        const { className, title, topContentRenderer, children } = this.props;
-        return (
-            <>
-                <DocumentTitle title={title} />
-                {topContentRenderer && topContentRenderer()}
-                <div className={className}>{children}</div>
-            </>
-        );
-    }
-}
+    return (
+        <>
+            <DocumentTitle title={title} />
+            {topContentRenderer && topContentRenderer()}
+            <div className={className}>{children}</div>
+        </>
+    );
+};
 
 export default Page;

--- a/src/test/components/pdf/PdfVisning.spec.tsx
+++ b/src/test/components/pdf/PdfVisning.spec.tsx
@@ -1,5 +1,5 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { act, screen, waitFor } from '@testing-library/react';
 
 import PdfVisning from '../../../app/components/pdf/PdfVisning';
 import { renderWithIntl } from '../../testUtils';
@@ -52,17 +52,13 @@ describe('<PdfVisning>', () => {
 
         expect(screen.getByTitle('pdf')).toHaveAttribute('src', '/api/k9-punsj/journalpost/200/dokument/123');
 
-        act(() => {
-            screen.getByTestId('dok-2').click();
-        });
+        fireEvent.click(screen.getByTestId('dok-2'));
 
         await waitFor(() => {
             expect(screen.getByTitle('pdf')).toHaveAttribute('src', '/api/k9-punsj/journalpost/200/dokument/456');
         });
 
-        act(() => {
-            screen.getByTestId('dok-1').click();
-        });
+        fireEvent.click(screen.getByTestId('dok-1'));
 
         await waitFor(() => {
             expect(screen.getByTitle('pdf')).toHaveAttribute('src', '/api/k9-punsj/journalpost/200/dokument/123');

--- a/src/test/containers/pleiepenger/PSBPunchForm.spec.tsx
+++ b/src/test/containers/pleiepenger/PSBPunchForm.spec.tsx
@@ -4,31 +4,31 @@ import { expect } from '@jest/globals';
 import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { mocked } from 'jest-mock';
 
-import { IntlProvider, IntlShape, createIntl } from 'react-intl';
-import { useSelector, useDispatch } from 'react-redux';
+import { createIntl, IntlProvider, IntlShape } from 'react-intl';
+import { useDispatch, useSelector } from 'react-redux';
 
-import intlHelper from '../../../app/utils/intlUtils';
 import {
     IPunchFormComponentProps,
     IPunchFormDispatchProps,
     IPunchFormStateProps,
     PunchFormComponent,
 } from '../../../app/søknader/pleiepenger/containers/PSBPunchForm';
+import intlHelper from '../../../app/utils/intlUtils';
 
+import userEvent from '@testing-library/user-event';
 import { JaNeiIkkeRelevant } from '../../../app/models/enums/JaNeiIkkeRelevant';
 import { IIdentState } from '../../../app/models/types/IdentState';
 import { IJournalposterPerIdentState } from '../../../app/models/types/Journalpost/JournalposterPerIdentState';
-import { IPSBSoknadKvittering } from '../../../app/models/types/PSBSoknadKvittering';
 import { IPSBSoknad } from '../../../app/models/types/PSBSoknad';
+import { IPSBSoknadKvittering } from '../../../app/models/types/PSBSoknadKvittering';
 import { IPunchPSBFormState } from '../../../app/models/types/PunchPSBFormState';
 import { ISignaturState } from '../../../app/models/types/SignaturState';
-import userEvent from '@testing-library/user-event';
-import { Tidsformat } from '../../../app/utils/timeUtils';
 import {
     createLandInputId,
     createPeriodInputIds,
     ENDRING_BEGRUNNELSE_INPUT_ID,
 } from '../../../app/søknader/pleiepenger/utils/errorAnchorUtils';
+import { Tidsformat } from '../../../app/utils/timeUtils';
 
 jest.mock('react-intl', () => ({
     ...jest.requireActual('react-intl'),
@@ -222,35 +222,27 @@ const setupPunchForm = (
 };
 
 describe('PunchForm', () => {
-    it('Viser skjema', async () => {
-        await act(async () => {
-            setupPunchForm();
-        });
+    it('Viser skjema', () => {
+        setupPunchForm();
 
         expect(screen.getAllByTestId(/accordionItem-/)).toHaveLength(7);
     });
 
-    it('Henter søknadsinformasjon', async () => {
+    it('Henter søknadsinformasjon', () => {
         const getSoknad = jest.fn();
-        await act(async () => {
-            setupPunchForm({}, { getSoknad });
-        });
+        setupPunchForm({}, { getSoknad });
         expect(getSoknad).toHaveBeenCalledTimes(1);
         expect(getSoknad).toHaveBeenCalledWith(soknadId);
     });
 
-    it('Viser spinner når søknaden lastes inn', async () => {
-        await act(async () => {
-            setupPunchForm({ isSoknadLoading: true });
-        });
+    it('Viser spinner når søknaden lastes inn', () => {
+        setupPunchForm({ isSoknadLoading: true });
 
         expect(screen.getByText(/Venter/i)).toBeDefined();
     });
 
-    it('Viser feilmelding når søknaden ikke er funnet', async () => {
-        await act(async () => {
-            setupPunchForm({ error: { status: 404 } });
-        });
+    it('Viser feilmelding når søknaden ikke er funnet', () => {
+        setupPunchForm({ error: { status: 404 } });
 
         expect(screen.getByText('Feil')).toBeDefined();
         expect(screen.getByText('skjema.feil.ikke_funnet')).toBeDefined();
@@ -261,16 +253,12 @@ describe('PunchForm', () => {
         const updateSoknad = jest.fn();
         const newDato = '11.02.2020';
 
-        await act(async () => {
-            setupPunchForm({ soknad: initialSoknad }, { updateSoknad });
-        });
+        setupPunchForm({ soknad: initialSoknad }, { updateSoknad });
 
         const dateInput = screen.getByTestId('mottattDato');
 
-        await act(async () => {
-            await userEvent.type(dateInput, newDato);
-            await userEvent.tab();
-        });
+        await userEvent.type(dateInput, newDato);
+        await userEvent.tab();
 
         // screen.debug(dateInput);
         // console.log(updateSoknad.mock);
@@ -282,35 +270,29 @@ describe('PunchForm', () => {
     });
 
     it('Oppdaterer felt når mottakelsesdato endres', async () => {
-        await act(async () => {
-            setupPunchForm({ soknad: initialSoknad });
-        });
+        setupPunchForm({ soknad: initialSoknad });
 
         const dateInput = screen.getByTestId('mottattDato') as HTMLInputElement;
 
         const newDato = '01.12.2024';
 
-        await act(async () => {
-            await userEvent.clear(dateInput);
-            await userEvent.type(dateInput, newDato);
-            await userEvent.tab();
-        });
+        await userEvent.clear(dateInput);
+        await userEvent.type(dateInput, newDato);
+        await userEvent.tab();
 
         expect(dateInput.value).toEqual(newDato);
     });
 
-    it('Viser dato for å legge til søknadsperiode når det ikke finnes en søknadsperiode fra før', async () => {
-        await act(async () => {
-            setupPunchForm({ soknad: initialSoknad }, {});
-            (useSelector as unknown as jest.Mock).mockImplementation((callback) =>
-                callback({
-                    PLEIEPENGER_SYKT_BARN: {
-                        punchFormState: {},
-                    },
-                    felles: { journalposterIAapenSoknad: [] },
-                }),
-            );
-        });
+    it('Viser dato for å legge til søknadsperiode når det ikke finnes en søknadsperiode fra før', () => {
+        setupPunchForm({ soknad: initialSoknad }, {});
+        (useSelector as unknown as jest.Mock).mockImplementation((callback) =>
+            callback({
+                PLEIEPENGER_SYKT_BARN: {
+                    punchFormState: {},
+                },
+                felles: { journalposterIAapenSoknad: [] },
+            }),
+        );
 
         const søknadsperioder = screen.getByTestId('søknadsperioder');
 
@@ -323,20 +305,16 @@ describe('PunchForm', () => {
         expect(periodepaneler).toHaveLength(1);
     });
 
-    it('Skjuler knapp for å legge til søknadsperiode når det finnes en søknadsperiode fra før', async () => {
+    it('Skjuler knapp for å legge til søknadsperiode når det finnes en søknadsperiode fra før', () => {
         const soknad = { ...initialSoknad, soeknadsperiode: [{ fom: '', tom: '' }] };
 
-        await act(async () => {
-            setupPunchForm({ soknad }, {});
-        });
+        setupPunchForm({ soknad }, {});
 
         expect(screen.queryByTestId('leggtilsoknadsperiode')).toBeNull();
     });
 
-    it('Viser checkboks for tilsyn (omsorgstilbud)', async () => {
-        await act(async () => {
-            setupPunchForm();
-        });
+    it('Viser checkboks for tilsyn (omsorgstilbud)', () => {
+        setupPunchForm();
 
         expect(screen.getByTestId('omsorgstilbud-checkboks')).toBeDefined();
     });
@@ -359,19 +337,15 @@ describe('PunchForm', () => {
                 ],
             },
         };
-        await act(async () => {
-            setupPunchForm({ soknad });
-        });
+        setupPunchForm({ soknad });
 
         const omsorgstilbudCheckboks = screen.getByTestId('omsorgstilbud-checkboks') as HTMLInputElement;
 
         expect(omsorgstilbudCheckboks.checked).toBeTruthy();
     });
 
-    it('Viser ikke perioder når tilsyn er undefined', async () => {
-        await act(async () => {
-            setupPunchForm({ soknad: initialSoknad });
-        });
+    it('Viser ikke perioder når tilsyn er undefined', () => {
+        setupPunchForm({ soknad: initialSoknad });
 
         const omsorgstilbudCheckboks = screen.getByTestId('omsorgstilbud-checkboks') as HTMLInputElement;
         expect(omsorgstilbudCheckboks.checked).toBeFalsy();
@@ -399,18 +373,14 @@ describe('PunchForm', () => {
                 },
             ],
         };
-        await act(async () => {
-            setupPunchForm({ soknad });
-        });
+        setupPunchForm({ soknad });
 
         expect(screen.getByTestId('beredskapsperioder')).toBeDefined();
         expect(screen.getByTestId('nattevaaksperioder')).toBeDefined();
     });
 
-    it('Viser ikke beredskap eller nattevåk hvis undefined', async () => {
-        await act(async () => {
-            setupPunchForm({ soknad: initialSoknad });
-        });
+    it('Viser ikke beredskap eller nattevåk hvis undefined', () => {
+        setupPunchForm({ soknad: initialSoknad });
 
         expect(screen.queryByTestId('beredskapsperioder')).toBeNull();
         expect(screen.queryByTestId('.nattevaaksperioder')).toBeNull();
@@ -419,38 +389,34 @@ describe('PunchForm', () => {
     it('Fjerner tilsynsordning når avhuking på tilsyn fjernes', async () => {
         const updateSoknad = jest.fn();
 
-        await act(async () => {
-            setupPunchForm(
-                {
-                    soknad: {
-                        ...initialSoknad,
-                        tilsynsordning: {
-                            perioder: [
-                                {
-                                    periode: {
-                                        fom: '2020-12-06',
-                                        tom: '2021-01-15',
-                                    },
-                                    timer: '5',
-                                    minutter: '0',
-                                    perDagString: '5 timer',
-                                    tidsformat: Tidsformat.TimerOgMin,
+        setupPunchForm(
+            {
+                soknad: {
+                    ...initialSoknad,
+                    tilsynsordning: {
+                        perioder: [
+                            {
+                                periode: {
+                                    fom: '2020-12-06',
+                                    tom: '2021-01-15',
                                 },
-                            ],
-                        },
+                                timer: '5',
+                                minutter: '0',
+                                perDagString: '5 timer',
+                                tidsformat: Tidsformat.TimerOgMin,
+                            },
+                        ],
                     },
                 },
-                { updateSoknad },
-            );
-        });
+            },
+            { updateSoknad },
+        );
 
         const omsorgstilbudCheckboks = screen.getByTestId('omsorgstilbud-checkboks') as HTMLInputElement;
 
         expect(omsorgstilbudCheckboks.checked).toBeTruthy();
 
-        await act(async () => {
-            fireEvent.click(omsorgstilbudCheckboks);
-        });
+        fireEvent.click(omsorgstilbudCheckboks);
 
         expect(omsorgstilbudCheckboks.checked).toBeFalsy();
     });
@@ -458,15 +424,11 @@ describe('PunchForm', () => {
     it('Validerer søknad når saksbehandler trykker på "Send inn"', async () => {
         const validateSoknad = jest.fn();
 
-        await act(async () => {
-            setupPunchForm({ soknad: initialSoknad }, { validateSoknad });
-        });
+        setupPunchForm({ soknad: initialSoknad }, { validateSoknad });
 
         const sendKnapp = screen.getByTestId('sendKnapp');
 
-        await act(async () => {
-            fireEvent.click(sendKnapp);
-        });
+        fireEvent.click(sendKnapp);
 
         expect(validateSoknad).toHaveBeenCalledTimes(1);
     });
@@ -474,27 +436,23 @@ describe('PunchForm', () => {
     it('Viser melding om valideringsfeil', async () => {
         const validateSoknad = jest.fn();
 
-        await act(async () => {
-            setupPunchForm(
-                {
-                    soknad: initialSoknad,
-                    inputErrors: [
-                        {
-                            felt: 'lovbestemtFerie',
-                            feilkode: 'ugyldigPreiode',
-                            feilmelding: 'Periode er utenfor søknadsperioden',
-                        },
-                    ],
-                },
-                { validateSoknad },
-            );
-        });
+        setupPunchForm(
+            {
+                soknad: initialSoknad,
+                inputErrors: [
+                    {
+                        felt: 'lovbestemtFerie',
+                        feilkode: 'ugyldigPreiode',
+                        feilmelding: 'Periode er utenfor søknadsperioden',
+                    },
+                ],
+            },
+            { validateSoknad },
+        );
 
         const sendKnapp = screen.getByTestId('sendKnapp');
 
-        await act(async () => {
-            fireEvent.click(sendKnapp);
-        });
+        fireEvent.click(sendKnapp);
 
         expect(validateSoknad).toHaveBeenCalledTimes(1);
         expect(await screen.findByText('Periode er utenfor søknadsperioden')).toBeDefined();
@@ -503,23 +461,19 @@ describe('PunchForm', () => {
     it('Viser fallback melding i ErrorSummary når validering feiler uten feltfeil', async () => {
         const validateSoknad = jest.fn();
 
-        await act(async () => {
-            setupPunchForm(
-                {
-                    soknad: initialSoknad,
-                    validateSoknadError: {
-                        message: 'Søknaden inneholder valideringsfeil',
-                    },
+        setupPunchForm(
+            {
+                soknad: initialSoknad,
+                validateSoknadError: {
+                    message: 'Søknaden inneholder valideringsfeil',
                 },
-                { validateSoknad },
-            );
-        });
+            },
+            { validateSoknad },
+        );
 
         const sendKnapp = screen.getByTestId('sendKnapp');
 
-        await act(async () => {
-            fireEvent.click(sendKnapp);
-        });
+        fireEvent.click(sendKnapp);
 
         expect(validateSoknad).toHaveBeenCalledTimes(1);
         expect(await screen.findByText('Søknaden inneholder valideringsfeil')).toBeDefined();
@@ -530,30 +484,26 @@ describe('PunchForm', () => {
         const periodKey = '../2029-02-15';
         const { fomId } = createPeriodInputIds('ytelse.søknadsperiode', periodKey);
 
-        await act(async () => {
-            setupPunchForm(
-                {
-                    soknad: {
-                        ...initialSoknad,
-                        soeknadsperiode: [{ fom: '', tom: '2029-02-15' }],
-                    },
-                    inputErrors: [
-                        {
-                            felt: "ytelse.uttak.perioder.['../2029-02-15']",
-                            feilkode: 'påkrevd',
-                            feilmelding: 'Fra og med (FOM) må være satt.',
-                        },
-                    ],
+        setupPunchForm(
+            {
+                soknad: {
+                    ...initialSoknad,
+                    soeknadsperiode: [{ fom: '', tom: '2029-02-15' }],
                 },
-                { validateSoknad },
-            );
-        });
+                inputErrors: [
+                    {
+                        felt: "ytelse.uttak.perioder.['../2029-02-15']",
+                        feilkode: 'påkrevd',
+                        feilmelding: 'Fra og med (FOM) må være satt.',
+                    },
+                ],
+            },
+            { validateSoknad },
+        );
 
         const sendKnapp = screen.getByTestId('sendKnapp');
 
-        await act(async () => {
-            fireEvent.click(sendKnapp);
-        });
+        fireEvent.click(sendKnapp);
 
         expect(validateSoknad).toHaveBeenCalledTimes(1);
 
@@ -568,30 +518,26 @@ describe('PunchForm', () => {
         const periodKey = '2026-02-02/..';
         const { tomId } = createPeriodInputIds('ytelse.søknadsperiode', periodKey);
 
-        await act(async () => {
-            setupPunchForm(
-                {
-                    soknad: {
-                        ...initialSoknad,
-                        soeknadsperiode: [{ fom: '2026-02-02', tom: '' }],
-                    },
-                    inputErrors: [
-                        {
-                            felt: 'ytelse.søknadsperiode[0].<list element>',
-                            feilkode: 'påkrevd',
-                            feilmelding: 'Til og med (TOM) må være satt.',
-                        },
-                    ],
+        setupPunchForm(
+            {
+                soknad: {
+                    ...initialSoknad,
+                    soeknadsperiode: [{ fom: '2026-02-02', tom: '' }],
                 },
-                { validateSoknad },
-            );
-        });
+                inputErrors: [
+                    {
+                        felt: 'ytelse.søknadsperiode[0].<list element>',
+                        feilkode: 'påkrevd',
+                        feilmelding: 'Til og med (TOM) må være satt.',
+                    },
+                ],
+            },
+            { validateSoknad },
+        );
 
         const sendKnapp = screen.getByTestId('sendKnapp');
 
-        await act(async () => {
-            fireEvent.click(sendKnapp);
-        });
+        fireEvent.click(sendKnapp);
 
         expect(validateSoknad).toHaveBeenCalledTimes(1);
 
@@ -606,34 +552,30 @@ describe('PunchForm', () => {
         const periodKey = '../2026-02-11';
         const { fomId } = createPeriodInputIds('endringAvSøknadsperioder', periodKey);
 
-        await act(async () => {
-            setupPunchForm(
-                {
-                    soknad: {
-                        ...initialSoknad,
-                        trekkKravPerioder: [
-                            { fom: '2026-01-01', tom: '2026-01-10' },
-                            { fom: '', tom: '2026-02-11' },
-                        ],
-                    },
-                    perioder: [{ fom: '2026-01-01', tom: '2026-01-31' }],
-                    inputErrors: [
-                        {
-                            felt: 'ytelse.trekkKravPerioder[1].<list element>',
-                            feilkode: 'påkrevd',
-                            feilmelding: 'Fra og med (FOM) må være satt.',
-                        },
+        setupPunchForm(
+            {
+                soknad: {
+                    ...initialSoknad,
+                    trekkKravPerioder: [
+                        { fom: '2026-01-01', tom: '2026-01-10' },
+                        { fom: '', tom: '2026-02-11' },
                     ],
                 },
-                { validateSoknad },
-            );
-        });
+                perioder: [{ fom: '2026-01-01', tom: '2026-01-31' }],
+                inputErrors: [
+                    {
+                        felt: 'ytelse.trekkKravPerioder[1].<list element>',
+                        feilkode: 'påkrevd',
+                        feilmelding: 'Fra og med (FOM) må være satt.',
+                    },
+                ],
+            },
+            { validateSoknad },
+        );
 
         const sendKnapp = screen.getByTestId('sendKnapp');
 
-        await act(async () => {
-            fireEvent.click(sendKnapp);
-        });
+        fireEvent.click(sendKnapp);
 
         expect(validateSoknad).toHaveBeenCalledTimes(1);
 
@@ -646,30 +588,26 @@ describe('PunchForm', () => {
     it('Viser ikke duplikat av begrunnelse-feil i endringsblokk', async () => {
         const validateSoknad = jest.fn();
 
-        await act(async () => {
-            setupPunchForm(
-                {
-                    soknad: {
-                        ...initialSoknad,
-                        trekkKravPerioder: [{ fom: '2026-02-01', tom: '2026-02-10' }],
-                    },
-                    perioder: [{ fom: '2026-02-01', tom: '2026-02-10' }],
-                    inputErrors: [
-                        {
-                            felt: 'begrunnelseForInnsending',
-                            feilkode: 'påkrevd',
-                            feilmelding: 'Du må legge inn en begrunnelse for å trekke perioder.',
-                        },
-                    ],
+        setupPunchForm(
+            {
+                soknad: {
+                    ...initialSoknad,
+                    trekkKravPerioder: [{ fom: '2026-02-01', tom: '2026-02-10' }],
                 },
-                { validateSoknad },
-            );
-        });
+                perioder: [{ fom: '2026-02-01', tom: '2026-02-10' }],
+                inputErrors: [
+                    {
+                        felt: 'begrunnelseForInnsending',
+                        feilkode: 'påkrevd',
+                        feilmelding: 'Du må legge inn en begrunnelse for å trekke perioder.',
+                    },
+                ],
+            },
+            { validateSoknad },
+        );
 
         const sendKnapp = screen.getByTestId('sendKnapp');
-        await act(async () => {
-            fireEvent.click(sendKnapp);
-        });
+        fireEvent.click(sendKnapp);
 
         const endringPanel = screen.getByTestId('accordionItem-endringAvSøknadsperioderpanel');
         const fieldErrors = within(endringPanel).queryAllByText(
@@ -681,35 +619,31 @@ describe('PunchForm', () => {
     it('Lenker ErrorSummary til begrunnelsefelt og dedupliserer samme melding', async () => {
         const validateSoknad = jest.fn();
 
-        await act(async () => {
-            setupPunchForm(
-                {
-                    soknad: {
-                        ...initialSoknad,
-                        trekkKravPerioder: [{ fom: '2026-02-01', tom: '2026-02-10' }],
-                    },
-                    perioder: [{ fom: '2026-02-01', tom: '2026-02-10' }],
-                    inputErrors: [
-                        {
-                            felt: 'begrunnelseForInnsending',
-                            feilkode: 'påkrevd',
-                            feilmelding: 'Du må legge inn en begrunnelse for å trekke perioder.',
-                        },
-                        {
-                            felt: 'begrunnelseForInnsending.tekst',
-                            feilkode: 'påkrevd',
-                            feilmelding: 'Du må legge inn en begrunnelse for å trekke perioder.',
-                        },
-                    ],
+        setupPunchForm(
+            {
+                soknad: {
+                    ...initialSoknad,
+                    trekkKravPerioder: [{ fom: '2026-02-01', tom: '2026-02-10' }],
                 },
-                { validateSoknad },
-            );
-        });
+                perioder: [{ fom: '2026-02-01', tom: '2026-02-10' }],
+                inputErrors: [
+                    {
+                        felt: 'begrunnelseForInnsending',
+                        feilkode: 'påkrevd',
+                        feilmelding: 'Du må legge inn en begrunnelse for å trekke perioder.',
+                    },
+                    {
+                        felt: 'begrunnelseForInnsending.tekst',
+                        feilkode: 'påkrevd',
+                        feilmelding: 'Du må legge inn en begrunnelse for å trekke perioder.',
+                    },
+                ],
+            },
+            { validateSoknad },
+        );
 
         const sendKnapp = screen.getByTestId('sendKnapp');
-        await act(async () => {
-            fireEvent.click(sendKnapp);
-        });
+        fireEvent.click(sendKnapp);
 
         const summaryLinks = screen.getAllByRole('link', {
             name: 'Du må legge inn en begrunnelse for å trekke perioder.',
@@ -721,29 +655,25 @@ describe('PunchForm', () => {
     it('Viser ikke duplikat av periodemelding i medlemskap-blokk', async () => {
         const validateSoknad = jest.fn();
 
-        await act(async () => {
-            setupPunchForm(
-                {
-                    soknad: {
-                        ...initialSoknad,
-                        bosteder: [{ periode: { fom: '2026-02-02', tom: '' }, land: '' }],
-                    },
-                    inputErrors: [
-                        {
-                            felt: "ytelse.bosteder.perioder.['2026-02-02/..']",
-                            feilkode: 'påkrevd',
-                            feilmelding: 'Til og med (TOM) må være satt.',
-                        },
-                    ],
+        setupPunchForm(
+            {
+                soknad: {
+                    ...initialSoknad,
+                    bosteder: [{ periode: { fom: '2026-02-02', tom: '' }, land: '' }],
                 },
-                { validateSoknad },
-            );
-        });
+                inputErrors: [
+                    {
+                        felt: "ytelse.bosteder.perioder.['2026-02-02/..']",
+                        feilkode: 'påkrevd',
+                        feilmelding: 'Til og med (TOM) må være satt.',
+                    },
+                ],
+            },
+            { validateSoknad },
+        );
 
         const sendKnapp = screen.getByTestId('sendKnapp');
-        await act(async () => {
-            fireEvent.click(sendKnapp);
-        });
+        fireEvent.click(sendKnapp);
 
         const medlemskapPanel = screen.getByTestId('accordionItem-medlemskappanel');
         const periodMessagesInPanel = within(medlemskapPanel).queryAllByText('Til og med (TOM) må være satt.');
@@ -754,31 +684,27 @@ describe('PunchForm', () => {
         const validateSoknad = jest.fn();
         const landId = createLandInputId('ytelse.utenlandsopphold', '2026-02-02/..');
 
-        await act(async () => {
-            setupPunchForm(
-                {
-                    soknad: {
-                        ...initialSoknad,
-                        utenlandsopphold: [{ periode: { fom: '2026-02-02', tom: '' }, land: '' }],
-                        utenlandsoppholdV2: [{ periode: { fom: '2026-02-02', tom: '' }, land: '' }],
-                    },
-                    inputErrors: [
-                        {
-                            felt: "ytelse.utenlandsopphold.perioder['2026-02-02/9999-12-31'].land",
-                            feilkode: 'nullFeil',
-                            feilmelding: 'Feltet kan ikke være tomt',
-                        },
-                    ],
+        setupPunchForm(
+            {
+                soknad: {
+                    ...initialSoknad,
+                    utenlandsopphold: [{ periode: { fom: '2026-02-02', tom: '' }, land: '' }],
+                    utenlandsoppholdV2: [{ periode: { fom: '2026-02-02', tom: '' }, land: '' }],
                 },
-                { validateSoknad },
-            );
-        });
+                inputErrors: [
+                    {
+                        felt: "ytelse.utenlandsopphold.perioder['2026-02-02/9999-12-31'].land",
+                        feilkode: 'nullFeil',
+                        feilmelding: 'Feltet kan ikke være tomt',
+                    },
+                ],
+            },
+            { validateSoknad },
+        );
 
         const sendKnapp = screen.getByTestId('sendKnapp');
 
-        await act(async () => {
-            fireEvent.click(sendKnapp);
-        });
+        fireEvent.click(sendKnapp);
 
         expect(validateSoknad).toHaveBeenCalledTimes(1);
 
@@ -791,29 +717,25 @@ describe('PunchForm', () => {
     it('Viser lovbestemt ferie valideringsfeil under periodfelt ved periodesti fra backend', async () => {
         const validateSoknad = jest.fn();
 
-        await act(async () => {
-            setupPunchForm(
-                {
-                    soknad: {
-                        ...initialSoknad,
-                        lovbestemtFerie: [{ fom: '', tom: '2026-02-25' }],
-                    },
-                    inputErrors: [
-                        {
-                            felt: "ytelse.lovbestemtFerie.perioder.['../2026-02-25']",
-                            feilkode: 'påkrevd',
-                            feilmelding: 'Fra og med (FOM) må være satt.',
-                        },
-                    ],
+        setupPunchForm(
+            {
+                soknad: {
+                    ...initialSoknad,
+                    lovbestemtFerie: [{ fom: '', tom: '2026-02-25' }],
                 },
-                { validateSoknad },
-            );
-        });
+                inputErrors: [
+                    {
+                        felt: "ytelse.lovbestemtFerie.perioder.['../2026-02-25']",
+                        feilkode: 'påkrevd',
+                        feilmelding: 'Fra og med (FOM) må være satt.',
+                    },
+                ],
+            },
+            { validateSoknad },
+        );
 
         const sendKnapp = screen.getByTestId('sendKnapp');
-        await act(async () => {
-            fireEvent.click(sendKnapp);
-        });
+        fireEvent.click(sendKnapp);
 
         expect(validateSoknad).toHaveBeenCalledTimes(1);
 
@@ -825,26 +747,21 @@ describe('PunchForm', () => {
     it('Lenker ErrorSummary til selvstendig næringsdrivende organisasjonsnummer for okOrganisasjonsnummer-feil', async () => {
         const validateSoknad = jest.fn();
 
-        await act(async () => {
-            setupPunchForm(
-                {
-                    inputErrors: [
-                        {
-                            felt: 'ytelse.opptjeningAktivitet.selvstendigNæringsdrivende[0].okOrganisasjonsnummer',
-                            feilkode: 'påkrevd',
-                            feilmelding:
-                                'organisasjonsnummer må være satt med mindre virksomhet er registrert i utlandet',
-                        },
-                    ],
-                },
-                { validateSoknad },
-            );
-        });
+        setupPunchForm(
+            {
+                inputErrors: [
+                    {
+                        felt: 'ytelse.opptjeningAktivitet.selvstendigNæringsdrivende[0].okOrganisasjonsnummer',
+                        feilkode: 'påkrevd',
+                        feilmelding: 'organisasjonsnummer må være satt med mindre virksomhet er registrert i utlandet',
+                    },
+                ],
+            },
+            { validateSoknad },
+        );
 
         const sendKnapp = screen.getByTestId('sendKnapp');
-        await act(async () => {
-            fireEvent.click(sendKnapp);
-        });
+        fireEvent.click(sendKnapp);
 
         expect(validateSoknad).toHaveBeenCalledTimes(1);
 
@@ -857,25 +774,21 @@ describe('PunchForm', () => {
     it('Lenker ErrorSummary til selvstendig næringsdrivende organisasjonsnummer for organisasjonsnummer.verdi-feil', async () => {
         const validateSoknad = jest.fn();
 
-        await act(async () => {
-            setupPunchForm(
-                {
-                    inputErrors: [
-                        {
-                            felt: 'ytelse.opptjeningAktivitet.selvstendigNæringsdrivende[0].organisasjonsnummer.verdi',
-                            feilkode: 'påkrevd',
-                            feilmelding: "'123456dfgj' matcher ikke tillatt pattern '^\\d+$'",
-                        },
-                    ],
-                },
-                { validateSoknad },
-            );
-        });
+        setupPunchForm(
+            {
+                inputErrors: [
+                    {
+                        felt: 'ytelse.opptjeningAktivitet.selvstendigNæringsdrivende[0].organisasjonsnummer.verdi',
+                        feilkode: 'påkrevd',
+                        feilmelding: "'123456dfgj' matcher ikke tillatt pattern '^\\d+$'",
+                    },
+                ],
+            },
+            { validateSoknad },
+        );
 
         const sendKnapp = screen.getByTestId('sendKnapp');
-        await act(async () => {
-            fireEvent.click(sendKnapp);
-        });
+        fireEvent.click(sendKnapp);
 
         expect(validateSoknad).toHaveBeenCalledTimes(1);
 
@@ -888,41 +801,37 @@ describe('PunchForm', () => {
     it('Viser bruttoinntekt-feil på feltet og lenker ErrorSummary til bruttoinntekt-feltet', async () => {
         const validateSoknad = jest.fn();
 
-        await act(async () => {
-            setupPunchForm(
-                {
-                    soknad: {
-                        ...initialSoknad,
-                        opptjeningAktivitet: {
-                            ...initialSoknad.opptjeningAktivitet,
-                            selvstendigNaeringsdrivende: {
-                                virksomhetNavn: 'Test virksomhet',
-                                organisasjonsnummer: '910909088',
-                                info: {
-                                    periode: { fom: '2026-02-02', tom: '' },
-                                    registrertIUtlandet: false,
-                                    virksomhetstyper: ['ANNEN'],
-                                    bruttoInntekt: '-16',
-                                },
+        setupPunchForm(
+            {
+                soknad: {
+                    ...initialSoknad,
+                    opptjeningAktivitet: {
+                        ...initialSoknad.opptjeningAktivitet,
+                        selvstendigNaeringsdrivende: {
+                            virksomhetNavn: 'Test virksomhet',
+                            organisasjonsnummer: '910909088',
+                            info: {
+                                periode: { fom: '2026-02-02', tom: '' },
+                                registrertIUtlandet: false,
+                                virksomhetstyper: ['ANNEN'],
+                                bruttoInntekt: '-16',
                             },
                         },
                     },
-                    inputErrors: [
-                        {
-                            felt: "ytelse.opptjeningAktivitet.selvstendigNæringsdrivende[0].perioder['2026-02-02/..'].bruttoInntekt",
-                            feilkode: 'ugyldigVerdi',
-                            feilmelding: 'bruttoInntekt [-16] må være >= 0.00',
-                        },
-                    ],
                 },
-                { validateSoknad },
-            );
-        });
+                inputErrors: [
+                    {
+                        felt: "ytelse.opptjeningAktivitet.selvstendigNæringsdrivende[0].perioder['2026-02-02/..'].bruttoInntekt",
+                        feilkode: 'ugyldigVerdi',
+                        feilmelding: 'bruttoInntekt [-16] må være >= 0.00',
+                    },
+                ],
+            },
+            { validateSoknad },
+        );
 
         const sendKnapp = screen.getByTestId('sendKnapp');
-        await act(async () => {
-            fireEvent.click(sendKnapp);
-        });
+        fireEvent.click(sendKnapp);
 
         expect(validateSoknad).toHaveBeenCalledTimes(1);
 
@@ -938,45 +847,41 @@ describe('PunchForm', () => {
     it('Viser virksomhetstyper-feil på feltet, dedupliserer duplikater og lenker ErrorSummary til feltgruppen', async () => {
         const validateSoknad = jest.fn();
 
-        await act(async () => {
-            setupPunchForm(
-                {
-                    soknad: {
-                        ...initialSoknad,
-                        opptjeningAktivitet: {
-                            ...initialSoknad.opptjeningAktivitet,
-                            selvstendigNaeringsdrivende: {
-                                virksomhetNavn: 'Test virksomhet',
-                                organisasjonsnummer: '910909088',
-                                info: {
-                                    periode: { fom: '2026-02-02', tom: null },
-                                    registrertIUtlandet: false,
-                                    virksomhetstyper: [],
-                                },
+        setupPunchForm(
+            {
+                soknad: {
+                    ...initialSoknad,
+                    opptjeningAktivitet: {
+                        ...initialSoknad.opptjeningAktivitet,
+                        selvstendigNaeringsdrivende: {
+                            virksomhetNavn: 'Test virksomhet',
+                            organisasjonsnummer: '910909088',
+                            info: {
+                                periode: { fom: '2026-02-02', tom: null },
+                                registrertIUtlandet: false,
+                                virksomhetstyper: [],
                             },
                         },
                     },
-                    inputErrors: [
-                        {
-                            felt: "ytelse.opptjeningAktivitet.selvstendigNæringsdrivende[0].perioder['2026-02-02/..'].virksomhetstyper",
-                            feilkode: 'nullFeil',
-                            feilmelding: 'Feltet kan ikke være tomt',
-                        },
-                        {
-                            felt: "ytelse.opptjeningAktivitet.selvstendigNæringsdrivende[0].perioder['2026-02-02/..'].virksomhetstyper",
-                            feilkode: 'tomFeil',
-                            feilmelding: 'Feltet kan ikke være tomt',
-                        },
-                    ],
                 },
-                { validateSoknad },
-            );
-        });
+                inputErrors: [
+                    {
+                        felt: "ytelse.opptjeningAktivitet.selvstendigNæringsdrivende[0].perioder['2026-02-02/..'].virksomhetstyper",
+                        feilkode: 'nullFeil',
+                        feilmelding: 'Feltet kan ikke være tomt',
+                    },
+                    {
+                        felt: "ytelse.opptjeningAktivitet.selvstendigNæringsdrivende[0].perioder['2026-02-02/..'].virksomhetstyper",
+                        feilkode: 'tomFeil',
+                        feilmelding: 'Feltet kan ikke være tomt',
+                    },
+                ],
+            },
+            { validateSoknad },
+        );
 
         const sendKnapp = screen.getByTestId('sendKnapp');
-        await act(async () => {
-            fireEvent.click(sendKnapp);
-        });
+        fireEvent.click(sendKnapp);
 
         expect(validateSoknad).toHaveBeenCalledTimes(1);
 
@@ -993,38 +898,36 @@ describe('PunchForm', () => {
     it('Viser frilanser arbeidstid-feil under kalenderseksjonen', async () => {
         const validateSoknad = jest.fn();
 
-        await act(async () => {
-            setupPunchForm(
-                {
-                    soknad: {
-                        ...initialSoknad,
-                        soeknadsperiode: [{ fom: '2026-02-16', tom: '2026-02-16' }],
-                        opptjeningAktivitet: {
-                            ...initialSoknad.opptjeningAktivitet,
-                            frilanser: {
-                                startdato: '2026-02-16',
-                                sluttdato: undefined,
-                                jobberFortsattSomFrilans: true,
-                            },
-                        },
-                        arbeidstid: {
-                            ...initialSoknad.arbeidstid,
-                            frilanserArbeidstidInfo: {
-                                perioder: [],
-                            },
+        setupPunchForm(
+            {
+                soknad: {
+                    ...initialSoknad,
+                    soeknadsperiode: [{ fom: '2026-02-16', tom: '2026-02-16' }],
+                    opptjeningAktivitet: {
+                        ...initialSoknad.opptjeningAktivitet,
+                        frilanser: {
+                            startdato: '2026-02-16',
+                            sluttdato: undefined,
+                            jobberFortsattSomFrilans: true,
                         },
                     },
-                    inputErrors: [
-                        {
-                            felt: "ytelse.arbeidstid.frilanserArbeidstidInfo.perioder['2026-02-16/2026-02-16'].jobberNormaltTimerPerDag",
-                            feilkode: 'ugyldigVerdi',
-                            feilmelding: 'Må være lavere eller lik 24 timer.',
+                    arbeidstid: {
+                        ...initialSoknad.arbeidstid,
+                        frilanserArbeidstidInfo: {
+                            perioder: [],
                         },
-                    ],
+                    },
                 },
-                { validateSoknad },
-            );
-        });
+                inputErrors: [
+                    {
+                        felt: "ytelse.arbeidstid.frilanserArbeidstidInfo.perioder['2026-02-16/2026-02-16'].jobberNormaltTimerPerDag",
+                        feilkode: 'ugyldigVerdi',
+                        feilmelding: 'Må være lavere eller lik 24 timer.',
+                    },
+                ],
+            },
+            { validateSoknad },
+        );
 
         const frilanserValidationErrors = await screen.findByTestId('frilanser-arbeidstid-validation-errors');
         expect(within(frilanserValidationErrors).getByText('Må være lavere eller lik 24 timer.')).toBeDefined();
@@ -1033,42 +936,40 @@ describe('PunchForm', () => {
     it('Viser selvstendig arbeidstid-feil under kalenderseksjonen', async () => {
         const validateSoknad = jest.fn();
 
-        await act(async () => {
-            setupPunchForm(
-                {
-                    soknad: {
-                        ...initialSoknad,
-                        soeknadsperiode: [{ fom: '2026-02-16', tom: '2026-02-16' }],
-                        opptjeningAktivitet: {
-                            ...initialSoknad.opptjeningAktivitet,
-                            selvstendigNaeringsdrivende: {
-                                virksomhetNavn: 'Test virksomhet',
-                                organisasjonsnummer: '910909088',
-                                info: {
-                                    periode: { fom: '2026-02-16', tom: '2026-02-16' },
-                                    registrertIUtlandet: false,
-                                    virksomhetstyper: ['ANNEN'],
-                                },
-                            },
-                        },
-                        arbeidstid: {
-                            ...initialSoknad.arbeidstid,
-                            selvstendigNæringsdrivendeArbeidstidInfo: {
-                                perioder: [],
+        setupPunchForm(
+            {
+                soknad: {
+                    ...initialSoknad,
+                    soeknadsperiode: [{ fom: '2026-02-16', tom: '2026-02-16' }],
+                    opptjeningAktivitet: {
+                        ...initialSoknad.opptjeningAktivitet,
+                        selvstendigNaeringsdrivende: {
+                            virksomhetNavn: 'Test virksomhet',
+                            organisasjonsnummer: '910909088',
+                            info: {
+                                periode: { fom: '2026-02-16', tom: '2026-02-16' },
+                                registrertIUtlandet: false,
+                                virksomhetstyper: ['ANNEN'],
                             },
                         },
                     },
-                    inputErrors: [
-                        {
-                            felt: "ytelse.arbeidstid.selvstendigNæringsdrivendeArbeidstidInfo.perioder['2026-02-16/2026-02-16'].jobberNormaltTimerPerDag",
-                            feilkode: 'ugyldigVerdi',
-                            feilmelding: 'Må være lavere eller lik 24 timer.',
+                    arbeidstid: {
+                        ...initialSoknad.arbeidstid,
+                        selvstendigNæringsdrivendeArbeidstidInfo: {
+                            perioder: [],
                         },
-                    ],
+                    },
                 },
-                { validateSoknad },
-            );
-        });
+                inputErrors: [
+                    {
+                        felt: "ytelse.arbeidstid.selvstendigNæringsdrivendeArbeidstidInfo.perioder['2026-02-16/2026-02-16'].jobberNormaltTimerPerDag",
+                        feilkode: 'ugyldigVerdi',
+                        feilmelding: 'Må være lavere eller lik 24 timer.',
+                    },
+                ],
+            },
+            { validateSoknad },
+        );
 
         const selvstendigValidationErrors = await screen.findByTestId('selvstendig-arbeidstid-validation-errors');
         expect(within(selvstendigValidationErrors).getByText('Må være lavere eller lik 24 timer.')).toBeDefined();
@@ -1077,41 +978,37 @@ describe('PunchForm', () => {
     it('Lenker ErrorSummary til registrert land for legacy valideringRegistrertUtlandet-feil', async () => {
         const validateSoknad = jest.fn();
 
-        await act(async () => {
-            setupPunchForm(
-                {
-                    soknad: {
-                        ...initialSoknad,
-                        opptjeningAktivitet: {
-                            ...initialSoknad.opptjeningAktivitet,
-                            selvstendigNaeringsdrivende: {
-                                virksomhetNavn: 'Test virksomhet',
-                                organisasjonsnummer: '',
-                                info: {
-                                    periode: { fom: '2026-02-02', tom: '2026-02-20' },
-                                    registrertIUtlandet: true,
-                                    landkode: '',
-                                },
+        setupPunchForm(
+            {
+                soknad: {
+                    ...initialSoknad,
+                    opptjeningAktivitet: {
+                        ...initialSoknad.opptjeningAktivitet,
+                        selvstendigNaeringsdrivende: {
+                            virksomhetNavn: 'Test virksomhet',
+                            organisasjonsnummer: '',
+                            info: {
+                                periode: { fom: '2026-02-02', tom: '2026-02-20' },
+                                registrertIUtlandet: true,
+                                landkode: '',
                             },
                         },
                     },
-                    inputErrors: [
-                        {
-                            felt: "ytelse.opptjeningAktivitet.selvstendigNæringsdrivende[0].perioder['2026-02-02/2026-02-20'].valideringRegistrertUtlandet",
-                            feilkode:
-                                "Feil{felt='.landkode', feilkode='påkrevd', feilmelding='landkode må være satt, og kan ikke være null, dersom virksomhet er registrert i utlandet.'}",
-                            feilmelding: '',
-                        },
-                    ],
                 },
-                { validateSoknad },
-            );
-        });
+                inputErrors: [
+                    {
+                        felt: "ytelse.opptjeningAktivitet.selvstendigNæringsdrivende[0].perioder['2026-02-02/2026-02-20'].valideringRegistrertUtlandet",
+                        feilkode:
+                            "Feil{felt='.landkode', feilkode='påkrevd', feilmelding='landkode må være satt, og kan ikke være null, dersom virksomhet er registrert i utlandet.'}",
+                        feilmelding: '',
+                    },
+                ],
+            },
+            { validateSoknad },
+        );
 
         const sendKnapp = screen.getByTestId('sendKnapp');
-        await act(async () => {
-            fireEvent.click(sendKnapp);
-        });
+        fireEvent.click(sendKnapp);
 
         expect(validateSoknad).toHaveBeenCalledTimes(1);
 
@@ -1124,9 +1021,7 @@ describe('PunchForm', () => {
     it('Viser modal når saksbehandler trykker på "Send inn" og det er ingen valideringsfeil', async () => {
         const validateSoknad = jest.fn();
 
-        await act(async () => {
-            setupPunchForm({ soknad: initialSoknad, validertSoknad, isValid: true }, { validateSoknad });
-        });
+        setupPunchForm({ soknad: initialSoknad, validertSoknad, isValid: true }, { validateSoknad });
 
         const sendKnapp = screen.getByTestId('sendKnapp');
 
@@ -1149,9 +1044,7 @@ describe('PunchForm', () => {
 
     it('Viser modal når saksbehandler trykker på "Sett på vent" og det er ingen valideringsfeil', async () => {
         const validateSoknad = jest.fn();
-        await act(async () => {
-            setupPunchForm({ soknad: initialSoknad }, { validateSoknad });
-        });
+        setupPunchForm({ soknad: initialSoknad }, { validateSoknad });
 
         const ventKnapp = screen.getByTestId('ventKnapp');
 
@@ -1162,21 +1055,19 @@ describe('PunchForm', () => {
         expect(screen.getByTestId('settpaaventmodal')).toBeDefined();
     });
 
-    it('Viser advarsel om overlappende periode', async () => {
+    it('Viser advarsel om overlappende periode', () => {
         const soknad = {
             ...initialSoknad,
             soeknadsperiode: [{ fom: '2021-02-23', tom: '2021-08-23' }],
         };
 
-        await act(async () => {
-            setupPunchForm(
-                {
-                    soknad,
-                    perioder: [{ fom: '2021-01-30', tom: '2021-04-15' }],
-                },
-                {},
-            );
-        });
+        setupPunchForm(
+            {
+                soknad,
+                perioder: [{ fom: '2021-01-30', tom: '2021-04-15' }],
+            },
+            {},
+        );
 
         // TODO: Fix this test
 
@@ -1189,12 +1080,10 @@ describe('PunchForm', () => {
         // expect(screen.queryByText('skjema.soknadsperiode.overlapper')).not.toBeNull();
     });
 
-    it('Viser legg till ferie', async () => {
+    it('Viser legg till ferie', () => {
         const soknad = { ...initialSoknad };
 
-        await act(async () => {
-            setupPunchForm({ soknad }, {});
-        });
+        setupPunchForm({ soknad }, {});
 
         expect(screen.getByTestId('accordionItem-feriepanel')).toBeDefined();
 
@@ -1203,12 +1092,10 @@ describe('PunchForm', () => {
         expect(feriepanelCheckbox).toBeDefined();
     });
 
-    it('Viser legg till ferie og slettade perioder dersom det finns periode', async () => {
+    it('Viser legg till ferie og slettade perioder dersom det finns periode', () => {
         const soknad = { ...initialSoknad };
 
-        await act(async () => {
-            setupPunchForm({ soknad, perioder: [{ fom: '2021-01-30', tom: '2021-04-15' }] }, {});
-        });
+        setupPunchForm({ soknad, perioder: [{ fom: '2021-01-30', tom: '2021-04-15' }] }, {});
 
         const feriepanel = screen.getByTestId('accordionItem-feriepanel');
 
@@ -1218,15 +1105,13 @@ describe('PunchForm', () => {
         expect(getByText('skjema.ferie.fjern')).toBeDefined();
     });
 
-    it('Viser ferieperioder dersom det finnes', async () => {
+    it('Viser ferieperioder dersom det finnes', () => {
         const soknad = {
             ...initialSoknad,
             lovbestemtFerie: [{ fom: '2021-01-30', tom: '2021-04-15' }],
         };
 
-        await act(async () => {
-            setupPunchForm({ soknad, perioder: [{ fom: '2021-01-30', tom: '2021-04-15' }] }, {});
-        });
+        setupPunchForm({ soknad, perioder: [{ fom: '2021-01-30', tom: '2021-04-15' }] }, {});
 
         const feriepanel = screen.getByTestId('accordionItem-feriepanel');
 
@@ -1239,15 +1124,13 @@ describe('PunchForm', () => {
         expect(tom.value).toEqual('15.04.2021');
     });
 
-    it('Viser slettade ferieperioder dersom det finnes', async () => {
+    it('Viser slettade ferieperioder dersom det finnes', () => {
         const soknad = {
             ...initialSoknad,
             lovbestemtFerieSomSkalSlettes: [{ fom: '2021-01-30', tom: '2021-04-15' }],
         };
 
-        await act(async () => {
-            setupPunchForm({ soknad, perioder: [{ fom: '2021-01-30', tom: '2021-04-15' }] }, {});
-        });
+        setupPunchForm({ soknad, perioder: [{ fom: '2021-01-30', tom: '2021-04-15' }] }, {});
 
         const feriepanel = screen.getByTestId('accordionItem-feriepanel');
 

--- a/src/test/containers/pleiepenger/Periodepaneler.spec.tsx
+++ b/src/test/containers/pleiepenger/Periodepaneler.spec.tsx
@@ -1,15 +1,15 @@
-import { act, render, screen } from '@testing-library/react';
+import { TextField } from '@navikt/ds-react';
+import { render, screen } from '@testing-library/react';
 import { mocked } from 'jest-mock';
 import * as React from 'react';
-import { TextField } from '@navikt/ds-react';
 import { IntlShape } from 'react-intl';
 
-import { Periodeinfo } from '../../../app/models/types/Periodeinfo';
 import {
     IPeriodeinfopanelerProps,
     PeriodeinfoComponent,
     PeriodeinfoPaneler,
 } from '../../../app/components/periodeinfoPaneler/PeriodeinfoPaneler';
+import { Periodeinfo } from '../../../app/models/types/Periodeinfo';
 import intlHelper from '../../../app/utils/intlUtils';
 
 jest.mock('react-intl');
@@ -81,18 +81,14 @@ const setupPeriodepaneler = (periodepanelerPropsPartial?: Partial<IPeriodeinfopa
 };
 
 describe('Periodepaneler', () => {
-    it('Viser listepaneler', async () => {
-        await act(async () => {
-            setupPeriodepaneler();
-        });
+    it('Viser listepaneler', () => {
+        setupPeriodepaneler();
 
         expect(screen.getByTestId('listepanel')).toBeInTheDocument();
     });
 
-    it('Viser perioder som listeelementer', async () => {
-        await act(async () => {
-            setupPeriodepaneler();
-        });
+    it('Viser perioder som listeelementer', () => {
+        setupPeriodepaneler();
 
         const listItems = screen.getAllByTestId('listepaneler');
 


### PR DESCRIPTION
### **Behov / Bakgrunn**

Det finnes flere tester med unodvendig manuell `act(...)`-bruk. For React 19-forberedelser er det nyttig a rydde opp i dette for a redusere teststoy og fa et klarere baseline-niva.

### **Losning**

Fjernet unodvendig `act(...)` i utvalgte RTL-tester for `PSBPunchForm`, `Periodepaneler` og `PdfVisning`. Beholdt `act(...)` i de to modal-testene som fortsatt trenger det pa grunn av async oppdateringer i Aksel `Modal`. Konverterte ogsa `Page` fra class component til function component.