### PR TITLE
Forbered liten TypeScript 6 kompatibilitetsbatch

### DIFF
--- a/copilot-tasks/completed/typescript-6-compat-batch-3-standalone.md
+++ b/copilot-tasks/completed/typescript-6-compat-batch-3-standalone.md
@@ -1,0 +1,70 @@
+# Copilot task
+
+Keep task files short. Put long reasoning in local notes, not here.
+
+## Task
+
+- Title: Prepare the third TypeScript 6 compatibility batch for standalone app errors
+- Branch: `refactor/typescript-6-compat-batch-3-standalone`
+- Suggested agent: `default Copilot coding agent`
+- Prompt language: `English`
+
+## Goal
+
+- Fix the remaining small standalone `TypeScript 6` app errors in `PdfVisning` and `Personvelger`.
+- Keep this batch narrow and avoid pulling in the larger union narrowing or form typing tracks.
+
+## Scope
+
+- Allowed files:
+  - `src/app/components/pdf/PdfVisning.tsx`
+  - `src/app/components/person-velger/Personvelger.tsx`
+  - nearby small tests only if a tiny focused test is trivial
+  - `copilot-tasks/typescript-6-compat-batch-3-standalone.md`
+- Out of scope:
+  - `ArbeidstidKalender.tsx`
+  - `tilsyn/utils.ts`
+  - Redux `connect(...)`, `Formik`, `Yup`
+  - `tsconfig.spec.json` and `cypress/tsconfig.json`
+  - `package.json` and `yarn.lock`
+- Constraints:
+  - keep the change scoped
+  - reuse existing patterns
+  - follow `AGENTS.md`
+  - avoid broad casts and keep runtime behavior unchanged
+
+## Validation
+
+- Commands:
+  - `yarn tsc --noEmit -p tsconfig.json`
+  - `yarn dlx -p typescript@6.0.3 tsc --noEmit --pretty false -p tsconfig.json`
+- Skip or limitation note:
+  - add a focused test only if it is very small and local to the change
+
+## Prompt for Copilot
+
+Follow this task file. First update `Plan`, then implement the task, keep `Progress notes` short, and finish by updating `Outcome`.
+
+Fix the small standalone `TypeScript 6` app errors in `src/app/components/pdf/PdfVisning.tsx` and `src/app/components/person-velger/Personvelger.tsx`. Keep the work limited to those files unless a tiny nearby test is trivial. Preserve runtime behavior, avoid broad casts, and do not touch `ArbeidstidKalender`, `tilsyn/utils`, Redux `connect(...)`, `Formik`, `Yup`, `tsconfig.spec.json`, `cypress`, `package.json`, or `yarn.lock`. Run `yarn tsc --noEmit -p tsconfig.json` and `yarn dlx -p typescript@6.0.3 tsc --noEmit --pretty false -p tsconfig.json`, then record the result in `Outcome`.
+
+Suggested starter prompt:
+
+- `Follow copilot-tasks/typescript-6-compat-batch-3-standalone.md. First update Plan, then implement, keep Progress notes short, and finish by updating Outcome.`
+
+## Plan
+
+1. PdfVisning: add generic type to `reduce<IDokumentMedJournalpost[]>` and nullish-coalesce the optional-chaining spread to fix TS2740/TS2769.
+2. Personvelger: widen `hentBarn` `.then` callback parameter to `Response | Error` and narrow with `instanceof` to fix TS2345.
+3. Run TS5 and TS6 validation.
+4. Update Outcome.
+
+## Progress notes
+
+- PdfVisning: added `reduce<IDokumentMedJournalpost[]>` generic, nullish-coalesced the optional-chaining spread (`?? []`), removed the eslint-disable comment. Also added trailing `?? []` for the outer optional chain.
+- Personvelger: removed explicit `: Response` annotation, added `instanceof Error` guard before `.ok` check.
+
+## Outcome
+
+- Changed files: `src/app/components/pdf/PdfVisning.tsx`, `src/app/components/person-velger/Personvelger.tsx`
+- Validation: `yarn tsc --noEmit` passes (TS5). `yarn dlx -p typescript@6.0.3 tsc --noEmit --pretty false` shows 0 errors in these files (27 remaining project-wide, all outside scope).
+- Remaining follow ups: 27 TS6 errors remain in other files (Redux `connect`, Formik, union narrowing tracks).

--- a/copilot-tasks/personvelger-barn-warning.md
+++ b/copilot-tasks/personvelger-barn-warning.md
@@ -1,0 +1,66 @@
+# Copilot task
+
+Keep task files short. Put long reasoning in local notes, not here.
+
+## Task
+
+- Title: Add non-blocking warning when barn autofill fails in Personvelger
+- Branch: `refactor/typescript-6-compat-batch-3-standalone`
+- Suggested agent: `default Copilot coding agent`
+- Prompt language: `English`
+
+## Goal
+
+- Show a small non-blocking warning when `Personvelger` fails to auto-fetch barn for the `OMPMA` flow.
+- Keep the form usable and do not turn this into a validation error.
+
+## Scope
+
+- Allowed files:
+  - `src/app/components/person-velger/Personvelger.tsx`
+  - `src/app/components/person-velger/personvelger.css`
+  - a tiny nearby test only if it is very small and local
+  - `copilot-tasks/personvelger-barn-warning.md`
+- Out of scope:
+  - broader form refactors
+  - blocking validation or submit changes
+  - `OMPUT` behavior changes beyond what falls out of the shared component
+  - `package.json` and `yarn.lock`
+- Constraints:
+  - keep the change scoped
+  - reuse existing patterns and Aksel components
+  - follow `AGENTS.md`
+  - use a non-blocking warning, not a validation error
+  - preserve manual fallback via `Legg til person`
+
+## Validation
+
+- Commands:
+  - `yarn tsc --noEmit -p tsconfig.json`
+  - `yarn lint`
+- Skip or limitation note:
+  - add a focused test only if it is very small and local to the component
+
+## Prompt for Copilot
+
+Follow this task file. First update `Plan`, then implement the task, keep `Progress notes` short, and finish by updating `Outcome`.
+
+Add a small non-blocking warning in `src/app/components/person-velger/Personvelger.tsx` for the case where `hentBarn(...)` returns `Error` while `populerMedBarn` is enabled. Keep the form usable, do not turn this into a validation error, and preserve manual fallback through `Legg til person`. Limit the work to `Personvelger` and local styling unless a tiny local test is trivial. Run `yarn tsc --noEmit -p tsconfig.json` and `yarn lint`, then record the result in `Outcome`.
+
+Suggested starter prompt:
+
+- `Follow copilot-tasks/personvelger-barn-warning.md. First update Plan, then implement, keep Progress notes short, and finish by updating Outcome.`
+
+## Plan
+
+- 3 to 6 short steps.
+
+## Progress notes
+
+- Short factual notes only.
+
+## Outcome
+
+- Changed files:
+- Validation:
+- Remaining follow ups:

--- a/copilot-tasks/typescript-6-compat-batch-4-union-narrowing.md
+++ b/copilot-tasks/typescript-6-compat-batch-4-union-narrowing.md
@@ -1,0 +1,67 @@
+# Copilot task
+
+Keep task files short. Put long reasoning in local notes, not here.
+
+## Task
+
+- Title: Prepare the fourth TypeScript 6 compatibility batch for union narrowing
+- Branch: `refactor/typescript-6-compat-batch-3-standalone`
+- Suggested agent: `default Copilot coding agent`
+- Prompt language: `English`
+
+## Goal
+
+- Fix the next small `TypeScript 6` app-level union narrowing errors in `ArbeidstidKalender` and `tilsyn/utils`.
+- Keep this batch limited to those two related files and do not mix in Redux, Formik, or Yup work.
+
+## Scope
+
+- Allowed files:
+  - `src/app/components/arbeidstid/ArbeidstidKalender.tsx`
+  - `src/app/components/tilsyn/utils.ts`
+  - a tiny nearby test only if it is very small and local
+  - `copilot-tasks/typescript-6-compat-batch-4-union-narrowing.md`
+- Out of scope:
+  - Redux `connect(...)` and HOC typing
+  - `Formik` generics
+  - `Yup` schemas
+  - `tsconfig.spec.json` and `cypress/tsconfig.json`
+  - `package.json` and `yarn.lock`
+- Constraints:
+  - keep the change scoped
+  - reuse existing patterns
+  - follow `AGENTS.md`
+  - avoid broad casts
+  - preserve runtime behavior
+
+## Validation
+
+- Commands:
+  - `yarn tsc --noEmit -p tsconfig.json`
+  - `yarn dlx -p typescript@6.0.3 tsc --noEmit --pretty false -p tsconfig.json`
+- Skip or limitation note:
+  - add a focused test only if it is very small and local to the affected logic
+
+## Prompt for Copilot
+
+Follow this task file. First update `Plan`, then implement the task, keep `Progress notes` short, and finish by updating `Outcome`.
+
+Fix the next `TypeScript 6` union narrowing errors in `src/app/components/arbeidstid/ArbeidstidKalender.tsx` and `src/app/components/tilsyn/utils.ts`. Keep the work limited to those files unless a tiny local test is trivial. Preserve runtime behavior, avoid broad casts, and do not touch Redux `connect(...)`, `Formik`, `Yup`, `tsconfig.spec.json`, `cypress`, `package.json`, or `yarn.lock`. Run `yarn tsc --noEmit -p tsconfig.json` and `yarn dlx -p typescript@6.0.3 tsc --noEmit --pretty false -p tsconfig.json`, then record the result in `Outcome`.
+
+Suggested starter prompt:
+
+- `Follow copilot-tasks/typescript-6-compat-batch-4-union-narrowing.md. First update Plan, then implement, keep Progress notes short, and finish by updating Outcome.`
+
+## Plan
+
+- 3 to 6 short steps.
+
+## Progress notes
+
+- Short factual notes only.
+
+## Outcome
+
+- Changed files:
+- Validation:
+- Remaining follow ups:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Kort logg over merkbare repo-endringer og oppsettendringer.
 
+### TypeScript 6 standalone batch for PdfVisning og Personvelger (2026-05-11)
+
+- Fullførte en liten oppfølgingsbatch for `TypeScript 6` ved å rydde typingen i `PdfVisning` og `Personvelger` uten å blande inn større spor som union narrowing, `Formik` eller `Yup`.
+- Arkiverte den tilhørende Copilot-taskfilen i `copilot-tasks/completed/`.
+
 ### TypeScript 6 useReducer batch og kortere Copilot taskfiler (2026-05-11)
 
 - Fullførte neste forberedende `TypeScript 6`-batch ved å gjøre de tre `pfArbeidstakerReducer`-variantene kompatible med strengere `useReducer`-typing uten endringer i runtime-flyt.

--- a/src/app/components/pdf/PdfVisning.tsx
+++ b/src/app/components/pdf/PdfVisning.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { ChevronLeftIcon, ChevronRightIcon } from '@navikt/aksel-icons';
-import { Button, Box, ToggleGroup } from '@navikt/ds-react';
+import { Box, Button, ToggleGroup } from '@navikt/ds-react';
 
 import { IJournalpostDokumenter } from 'app/models/enums/Journalpost/JournalpostDokumenter';
 
@@ -51,15 +51,14 @@ const PdfVisning: React.FunctionComponent<IPdfVisningProps> = ({ journalpostDoku
         journalpostid,
         dokumentId: dokument.dokumentId,
     });
-    const dokumenter: IDokumentMedJournalpost[] = journalpostDokumenter?.reduce(
-        (prev, current) => [
-            ...prev,
-            // TODO Fix this eslint error
-            // eslint-disable-next-line no-unsafe-optional-chaining
-            ...current.dokumenter?.map((dokument) => mapDokument(dokument, current.journalpostid)),
-        ],
-        [],
-    );
+    const dokumenter: IDokumentMedJournalpost[] =
+        journalpostDokumenter?.reduce<IDokumentMedJournalpost[]>(
+            (prev, current) => [
+                ...prev,
+                ...(current.dokumenter?.map((dokument) => mapDokument(dokument, current.journalpostid)) ?? []),
+            ],
+            [],
+        ) ?? [];
 
     const dokumentnummer = useMemo<number>(() => dokumentnr(dok, dokumenter), [dokumenter, dok]);
     const dokument = dokumenter[dokumentnummer - 1];

--- a/src/app/components/person-velger/Personvelger.tsx
+++ b/src/app/components/person-velger/Personvelger.tsx
@@ -24,7 +24,10 @@ const Personvelger = ({ handleBlur, name, sokersIdent, populerMedBarn }: OwnProp
 
     useEffect(() => {
         if (populerMedBarn && sokersIdent) {
-            hentBarn(sokersIdent).then((response: Response) => {
+            hentBarn(sokersIdent).then((response) => {
+                if (response instanceof Error) {
+                    return;
+                }
                 if (response.ok) {
                     response.json().then((data) => {
                         if (data.barn?.length) {


### PR DESCRIPTION
### Behov / Bakgrunn

Prosjektet rydder TypeScript 6-kompatibilitet i små batcher før selve oppgraderingen. Denne PR-en tar to små, isolerte app-feil som ikke trenger større refaktorering.

### Løsning

- rydder TypeScript 6-typing i `PdfVisning`
- rydder TypeScript 6-typing i `Personvelger`