### PR TITLE
Oppgrader distroless runtime til Debian 13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs22-debian12:nonroot
+FROM gcr.io/distroless/nodejs22-debian13:nonroot
 
 ENV TZ="Europe/Oslo"
 ENV NODE_ENV=production

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Kort logg over merkbare repo-endringer og oppsettendringer.
 
+### Distroless runtime moved to Debian 13 (2026-05-19)
+
+- Løftet produksjonsbildet fra `gcr.io/distroless/nodejs22-debian12:nonroot` til `gcr.io/distroless/nodejs22-debian13:nonroot` for å få med nyere `openssl`- og `glibc`-fikser i runtime-imaget som Trivy scanner etter deploy.
+
 ### TypeScript 6.0.3 compiler upgrade (2026-05-15)
 
 - Løftet `typescript` til `6.0.3` etter å ha ryddet de siste repo-spesifikke TS6-kompatibilitetsfeilene i validering, søknadsflyter og testoppsett.


### PR DESCRIPTION
### Behov / Bakgrunn

Trivy-funnene på `master` kommer fra runtime-imaget, ikke fra frontend- eller server-avhengighetene i repoet. Dagens baseimage `gcr.io/distroless/nodejs22-debian12:nonroot` drar fortsatt med sårbare `openssl`- og `glibc`-versjoner.

### Løsning

Bytter baseimage i `Dockerfile` til `gcr.io/distroless/nodejs22-debian13:nonroot`.
Legger også inn en kort changelog-note for endringen i produksjonsruntime.

### Andre endringer

Ingen funksjonelle endringer i app-kode eller proxy-logikk.
Restusikkerhet må fortsatt bekreftes etter deploy, særlig outbound TLS, proxy-kall og samspill med Azure sidecar.