### PR TITLE
Fiks SentryCli interop i sentry-release scriptet

### DIFF
--- a/src/build/scripts/sentry-release.js
+++ b/src/build/scripts/sentry-release.js
@@ -1,6 +1,10 @@
-import sentryCliPkg from '@sentry/cli';
+import * as sentryCliPkg from '@sentry/cli';
 
-const { SentryCli } = sentryCliPkg;
+const SentryCli = sentryCliPkg.SentryCli ?? sentryCliPkg.default?.SentryCli ?? sentryCliPkg.default;
+
+if (typeof SentryCli !== 'function') {
+    throw new Error('Unable to resolve SentryCli constructor from @sentry/cli');
+}
 
 async function opprettReleaseTilSentry() {
     const release = process.env.SENTRY_RELEASE;


### PR DESCRIPTION
### Behov / Bakgrunn

`yarn sentry-release` feilet fortsatt i GitHub Actions etter forrige oppdatering av importen fra `@sentry/cli`.

Den første feilen var at `SentryCli` ikke kunne importeres som named export fra en CommonJS-pakke i ESM-runtime. Den oppfølgingsendringen fjernet denne feilen, men var for snever og ga i CI en ny feil: `TypeError: SentryCli is not a constructor`.

### Løsning

Normaliserte hvordan `SentryCli` hentes fra `@sentry/cli` i `src/build/scripts/sentry-release.js`, slik at scriptet tåler både direkte `SentryCli`-eksport og CommonJS default-interop.

La også inn en eksplisitt guard som feiler tydelig hvis konstruktøren ikke kan løses.