### PR TITLE
Fix korrigering av inntektsmelding autosave for ugyldig delvis fravær tid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Kort logg over merkbare repo-endringer og oppsettendringer.
 
+### Stabilisering av delvis fravær i korrigering av inntektsmelding (2026-07-07)
+
+- Fikset `Korrigering av inntektsmelding` slik at feltet `Timer` i `delvis fravær` ikke lenger sender ugyldige mellomtilstander som `.` eller andre ufullstendige desimalverdier videre til `PUT /api/omsorgspenger-soknad/oppdater`.
+- La inn lokal validering og serialiseringsguard som holder feltet til timer og desimaltimer i gyldig format, slik at ugyldig mellominput stoppes i frontend i stedet for å gi backend-feil som `Ugyldig tid`.
+- Strammet samtidig inn formatstøtten i feltet til vanlige timer- og desimaltimerverdier, og la til målrettede unit tester for payload-bygging og validering av delvis fravær.
+
 ### UI-opprydding i punchskjemaer (2026-07-03)
 
 - La inn felles toppnivå-titler i punchskjemaene basert på samme dokumenttypenavn som i `Fordeling`, blant annet for `PSB`, `PLS`, `OMPKS`, `OMPMA`, `OMPUT`, `OMPAO`, `OLP` og `Korrigering av inntektsmelding`, og strammet samtidig inn vertikal rytme rundt disse overskriftene.

--- a/src/app/models/types/OMSKorrigering.ts
+++ b/src/app/models/types/OMSKorrigering.ts
@@ -1,4 +1,5 @@
 import { KorrigeringAvInntektsmeldingFormValues } from 'app/søknader/korrigeringAvInntektsmelding/types/KorrigeringAvInntektsmeldingFormFieldsValues';
+import { normaliserDelvisFravaerTimer } from 'app/søknader/korrigeringAvInntektsmelding/tidUtils';
 
 import { IPeriode } from './Periode';
 
@@ -28,10 +29,12 @@ const lagFraværsperioder = (values: KorrigeringAvInntektsmeldingFormValues) => 
     }
     if (values.DagerMedDelvisFravær.length > 0 && values.DagerMedDelvisFravær[0].dato) {
         values.DagerMedDelvisFravær.forEach((dagMedDelvisFravær) => {
-            if (dagMedDelvisFravær.dato || dagMedDelvisFravær.timer) {
+            const normalisertTimer = normaliserDelvisFravaerTimer(dagMedDelvisFravær.timer);
+
+            if (dagMedDelvisFravær.dato && normalisertTimer) {
                 fraværsperioder.push({
                     periode: { fom: dagMedDelvisFravær.dato, tom: dagMedDelvisFravær.dato },
-                    faktiskTidPrDag: dagMedDelvisFravær.timer,
+                    faktiskTidPrDag: normalisertTimer,
                 });
             }
         });

--- a/src/app/models/types/OMSKorrigering.ts
+++ b/src/app/models/types/OMSKorrigering.ts
@@ -11,23 +11,31 @@ export interface Fravaersperioder {
 const lagFraværsperioder = (values: KorrigeringAvInntektsmeldingFormValues) => {
     const fraværsperioder: Fravaersperioder[] = [];
 
-    if (values.Trekkperioder.length > 0 && values.Trekkperioder[0].fom) {
+    if (values.Trekkperioder.length > 0) {
         values.Trekkperioder.forEach((trekkperiode) => {
+            if (!trekkperiode.fom) {
+                return;
+            }
+
             fraværsperioder.push({
                 periode: trekkperiode,
                 faktiskTidPrDag: '0',
             });
         });
     }
-    if (values.PerioderMedRefusjonskrav.length > 0 && values.PerioderMedRefusjonskrav[0].fom) {
+    if (values.PerioderMedRefusjonskrav.length > 0) {
         values.PerioderMedRefusjonskrav.forEach((periodeMedRefusjonskrav) => {
+            if (!periodeMedRefusjonskrav.fom) {
+                return;
+            }
+
             fraværsperioder.push({
                 periode: periodeMedRefusjonskrav,
                 faktiskTidPrDag: null,
             });
         });
     }
-    if (values.DagerMedDelvisFravær.length > 0 && values.DagerMedDelvisFravær[0].dato) {
+    if (values.DagerMedDelvisFravær.length > 0) {
         values.DagerMedDelvisFravær.forEach((dagMedDelvisFravær) => {
             const normalisertTimer = normaliserDelvisFraværTimer(dagMedDelvisFravær.timer);
 

--- a/src/app/models/types/OMSKorrigering.ts
+++ b/src/app/models/types/OMSKorrigering.ts
@@ -1,5 +1,5 @@
 import { KorrigeringAvInntektsmeldingFormValues } from 'app/søknader/korrigeringAvInntektsmelding/types/KorrigeringAvInntektsmeldingFormFieldsValues';
-import { normaliserDelvisFravaerTimer } from 'app/søknader/korrigeringAvInntektsmelding/tidUtils';
+import { normaliserDelvisFraværTimer } from 'app/søknader/korrigeringAvInntektsmelding/tidUtils';
 
 import { IPeriode } from './Periode';
 
@@ -29,7 +29,7 @@ const lagFraværsperioder = (values: KorrigeringAvInntektsmeldingFormValues) => 
     }
     if (values.DagerMedDelvisFravær.length > 0 && values.DagerMedDelvisFravær[0].dato) {
         values.DagerMedDelvisFravær.forEach((dagMedDelvisFravær) => {
-            const normalisertTimer = normaliserDelvisFravaerTimer(dagMedDelvisFravær.timer);
+            const normalisertTimer = normaliserDelvisFraværTimer(dagMedDelvisFravær.timer);
 
             if (dagMedDelvisFravær.dato && normalisertTimer) {
                 fraværsperioder.push({

--- a/src/app/søknader/korrigeringAvInntektsmelding/containers/korrigeringAvFormValidering.ts
+++ b/src/app/søknader/korrigeringAvInntektsmelding/containers/korrigeringAvFormValidering.ts
@@ -7,6 +7,7 @@ import {
     KorrigeringAvInntektsmeldingFormFields,
     KorrigeringAvInntektsmeldingFormValues,
 } from '../types/KorrigeringAvInntektsmeldingFormFieldsValues';
+import { parseDelvisFravaerTimerTilTimer } from '../tidUtils';
 
 export interface FormErrors {
     OpplysningerOmKorrigering: {
@@ -217,13 +218,19 @@ export const getFormErrors = (values: KorrigeringAvInntektsmeldingFormValues, da
     });
     values.DagerMedDelvisFravær.forEach((value, index) => {
         errors.DagerMedDelvisFravær.push({ dato: '', timer: '' });
-        if (value.dato && !value.timer) {
+        const timerInput = value.timer.replace(/\s+/g, '');
+
+        if (value.dato && !timerInput) {
             errors.DagerMedDelvisFravær[index].timer = 'Du må fylle inn timer';
-        } else if (!value.dato && value.timer) {
+        } else if (!value.dato && timerInput) {
             errors.DagerMedDelvisFravær[index].dato = 'Dato må være satt';
-        } else if (value.timer) {
-            const timetall = value.timer.replace(/,/g, '.').replace(/\s+/g, '');
-            if (Number(timetall) > 7.5) {
+        } else if (timerInput) {
+            const timetall = parseDelvisFravaerTimerTilTimer(timerInput);
+
+            if (timetall === null) {
+                errors.DagerMedDelvisFravær[index].timer =
+                    'Timer må være oppgitt som timer, desimaltimer eller timer:minutter';
+            } else if (timetall > 7.5) {
                 errors.DagerMedDelvisFravær[index].timer = 'Delvis fravær kan ikke overstige 7 timer og 30 min';
             }
         }

--- a/src/app/søknader/korrigeringAvInntektsmelding/containers/korrigeringAvFormValidering.ts
+++ b/src/app/søknader/korrigeringAvInntektsmelding/containers/korrigeringAvFormValidering.ts
@@ -7,7 +7,7 @@ import {
     KorrigeringAvInntektsmeldingFormFields,
     KorrigeringAvInntektsmeldingFormValues,
 } from '../types/KorrigeringAvInntektsmeldingFormFieldsValues';
-import { parseDelvisFravaerTimerTilTimer } from '../tidUtils';
+import { parseDelvisFraværTimerTilTimer } from '../tidUtils';
 
 export interface FormErrors {
     OpplysningerOmKorrigering: {
@@ -225,11 +225,10 @@ export const getFormErrors = (values: KorrigeringAvInntektsmeldingFormValues, da
         } else if (!value.dato && timerInput) {
             errors.DagerMedDelvisFravær[index].dato = 'Dato må være satt';
         } else if (timerInput) {
-            const timetall = parseDelvisFravaerTimerTilTimer(timerInput);
+            const timetall = parseDelvisFraværTimerTilTimer(timerInput);
 
             if (timetall === null) {
-                errors.DagerMedDelvisFravær[index].timer =
-                    'Timer må være oppgitt som timer, desimaltimer eller timer:minutter';
+                errors.DagerMedDelvisFravær[index].timer = 'Timer må være oppgitt som timer eller desimaltimer';
             } else if (timetall > 7.5) {
                 errors.DagerMedDelvisFravær[index].timer = 'Delvis fravær kan ikke overstige 7 timer og 30 min';
             }

--- a/src/app/søknader/korrigeringAvInntektsmelding/tidUtils.ts
+++ b/src/app/søknader/korrigeringAvInntektsmelding/tidUtils.ts
@@ -1,23 +1,12 @@
-const desimalTidPattern = /^(?=.*\d)\d*(?:[.,]\d*)?$/;
-const timerOgMinutterPattern = /^\d+:\d+$/;
+const desimalTidPattern = /^\d+(?:[.,]\d+)?$/;
 
 const fjernWhitespace = (value: string) => value.replace(/\s+/g, '');
 
-export const normaliserDelvisFravaerTimer = (value?: string | null): string | null => {
-    const normalisert = fjernWhitespace(value || '');
+export const normaliserDelvisFraværTimer = (value?: string | null): string | null => {
+    const normalisert = fjernWhitespace(value ?? '');
 
     if (!normalisert) {
         return null;
-    }
-
-    if (timerOgMinutterPattern.test(normalisert)) {
-        const [timer, minutter] = normalisert.split(':').map(Number);
-
-        if (Number.isNaN(timer) || Number.isNaN(minutter) || timer < 0 || minutter < 0 || minutter > 60) {
-            return null;
-        }
-
-        return normalisert;
     }
 
     if (desimalTidPattern.test(normalisert)) {
@@ -28,16 +17,11 @@ export const normaliserDelvisFravaerTimer = (value?: string | null): string | nu
     return null;
 };
 
-export const parseDelvisFravaerTimerTilTimer = (value?: string | null): number | null => {
-    const normalisert = normaliserDelvisFravaerTimer(value);
+export const parseDelvisFraværTimerTilTimer = (value?: string | null): number | null => {
+    const normalisert = normaliserDelvisFraværTimer(value);
 
     if (!normalisert) {
         return null;
-    }
-
-    if (normalisert.includes(':')) {
-        const [timer, minutter] = normalisert.split(':').map(Number);
-        return timer + minutter / 60;
     }
 
     return Number(normalisert.replace(',', '.'));

--- a/src/app/søknader/korrigeringAvInntektsmelding/tidUtils.ts
+++ b/src/app/søknader/korrigeringAvInntektsmelding/tidUtils.ts
@@ -1,0 +1,44 @@
+const decimalTidPattern = /^(?=.*\d)\d*(?:[.,]\d*)?$/;
+const timerOgMinutterPattern = /^\d+:\d+$/;
+
+const fjernWhitespace = (value: string) => value.replace(/\s+/g, '');
+
+export const normaliserDelvisFravaerTimer = (value?: string | null): string | null => {
+    const normalisert = fjernWhitespace(value || '');
+
+    if (!normalisert) {
+        return null;
+    }
+
+    if (timerOgMinutterPattern.test(normalisert)) {
+        const [timer, minutter] = normalisert.split(':').map(Number);
+
+        if (Number.isNaN(timer) || Number.isNaN(minutter) || timer < 0 || minutter < 0 || minutter > 60) {
+            return null;
+        }
+
+        return normalisert;
+    }
+
+    if (decimalTidPattern.test(normalisert)) {
+        const parsed = Number(normalisert.replace(',', '.'));
+        return Number.isNaN(parsed) || parsed < 0 ? null : normalisert;
+    }
+
+    return null;
+};
+
+export const parseDelvisFravaerTimerTilTimer = (value?: string | null): number | null => {
+    const normalisert = normaliserDelvisFravaerTimer(value);
+
+    if (!normalisert) {
+        return null;
+    }
+
+    if (normalisert.includes(':')) {
+        const [timer, minutter] = normalisert.split(':').map(Number);
+        return timer + minutter / 60;
+    }
+
+    return Number(normalisert.replace(',', '.'));
+};

--- a/src/app/søknader/korrigeringAvInntektsmelding/tidUtils.ts
+++ b/src/app/søknader/korrigeringAvInntektsmelding/tidUtils.ts
@@ -1,4 +1,4 @@
-const decimalTidPattern = /^(?=.*\d)\d*(?:[.,]\d*)?$/;
+const desimalTidPattern = /^(?=.*\d)\d*(?:[.,]\d*)?$/;
 const timerOgMinutterPattern = /^\d+:\d+$/;
 
 const fjernWhitespace = (value: string) => value.replace(/\s+/g, '');
@@ -20,7 +20,7 @@ export const normaliserDelvisFravaerTimer = (value?: string | null): string | nu
         return normalisert;
     }
 
-    if (decimalTidPattern.test(normalisert)) {
+    if (desimalTidPattern.test(normalisert)) {
         const parsed = Number(normalisert.replace(',', '.'));
         return Number.isNaN(parsed) || parsed < 0 ? null : normalisert;
     }

--- a/src/test/containers/korrigeringAvInntektsmelding/korrigeringAvFormValidering.spec.ts
+++ b/src/test/containers/korrigeringAvInntektsmelding/korrigeringAvFormValidering.spec.ts
@@ -83,22 +83,20 @@ describe('korrigeringAvFormValidering', () => {
     it('viser en frontend-feil når timer for delvis fravær har et ugyldig format', () => {
         const values: KorrigeringAvInntektsmeldingFormValues = {
             ...getValidValues(),
-            DagerMedDelvisFravær: [{ dato: '2026-02-12', timer: '.' }],
+            DagerMedDelvisFravær: [{ dato: '2026-02-12', timer: '5.' }],
         };
 
         const errors = getFormErrors(values) as {
             DagerMedDelvisFravær: Array<{ timer: string }>;
         };
 
-        expect(errors.DagerMedDelvisFravær[0].timer).toBe(
-            'Timer må være oppgitt som timer, desimaltimer eller timer:minutter',
-        );
+        expect(errors.DagerMedDelvisFravær[0].timer).toBe('Timer må være oppgitt som timer eller desimaltimer');
     });
 
-    it('bruker maksgrensen også for timer:minutter i delvis fravær', () => {
+    it('bruker maksgrensen også for desimaltimer i delvis fravær', () => {
         const values: KorrigeringAvInntektsmeldingFormValues = {
             ...getValidValues(),
-            DagerMedDelvisFravær: [{ dato: '2026-02-12', timer: '7:45' }],
+            DagerMedDelvisFravær: [{ dato: '2026-02-12', timer: '7,6' }],
         };
 
         const errors = getFormErrors(values) as {

--- a/src/test/containers/korrigeringAvInntektsmelding/korrigeringAvFormValidering.spec.ts
+++ b/src/test/containers/korrigeringAvInntektsmelding/korrigeringAvFormValidering.spec.ts
@@ -80,7 +80,7 @@ describe('korrigeringAvFormValidering', () => {
         expect(errors.DagerMedDelvisFravær[0].dato).toBe('Delvis fravær feil');
     });
 
-    it('shows a frontend error when delvis fravær timer has an unsupported format', () => {
+    it('viser en frontend-feil når timer for delvis fravær har et ugyldig format', () => {
         const values: KorrigeringAvInntektsmeldingFormValues = {
             ...getValidValues(),
             DagerMedDelvisFravær: [{ dato: '2026-02-12', timer: '.' }],
@@ -95,7 +95,7 @@ describe('korrigeringAvFormValidering', () => {
         );
     });
 
-    it('applies the max limit for timer:minutter input in delvis fravær', () => {
+    it('bruker maksgrensen også for timer:minutter i delvis fravær', () => {
         const values: KorrigeringAvInntektsmeldingFormValues = {
             ...getValidValues(),
             DagerMedDelvisFravær: [{ dato: '2026-02-12', timer: '7:45' }],

--- a/src/test/containers/korrigeringAvInntektsmelding/korrigeringAvFormValidering.spec.ts
+++ b/src/test/containers/korrigeringAvInntektsmelding/korrigeringAvFormValidering.spec.ts
@@ -79,4 +79,32 @@ describe('korrigeringAvFormValidering', () => {
         expect(errors.PerioderMedRefusjonskrav[0]).toBe('Refusjonskravfeil');
         expect(errors.DagerMedDelvisFravær[0].dato).toBe('Delvis fravær feil');
     });
+
+    it('shows a frontend error when delvis fravær timer has an unsupported format', () => {
+        const values: KorrigeringAvInntektsmeldingFormValues = {
+            ...getValidValues(),
+            DagerMedDelvisFravær: [{ dato: '2026-02-12', timer: '.' }],
+        };
+
+        const errors = getFormErrors(values) as {
+            DagerMedDelvisFravær: Array<{ timer: string }>;
+        };
+
+        expect(errors.DagerMedDelvisFravær[0].timer).toBe(
+            'Timer må være oppgitt som timer, desimaltimer eller timer:minutter',
+        );
+    });
+
+    it('applies the max limit for timer:minutter input in delvis fravær', () => {
+        const values: KorrigeringAvInntektsmeldingFormValues = {
+            ...getValidValues(),
+            DagerMedDelvisFravær: [{ dato: '2026-02-12', timer: '7:45' }],
+        };
+
+        const errors = getFormErrors(values) as {
+            DagerMedDelvisFravær: Array<{ timer: string }>;
+        };
+
+        expect(errors.DagerMedDelvisFravær[0].timer).toBe('Delvis fravær kan ikke overstige 7 timer og 30 min');
+    });
 });

--- a/src/test/models/types/OMSKorrigering.spec.ts
+++ b/src/test/models/types/OMSKorrigering.spec.ts
@@ -15,7 +15,7 @@ describe('OMSKorrigering', () => {
         const korrigering = new OMSKorrigering(
             {
                 ...getValidValues(),
-                DagerMedDelvisFravær: [{ dato: '2026-02-12', timer: '.' }],
+                DagerMedDelvisFravær: [{ dato: '2026-02-12', timer: '5.' }],
             },
             'soknad-id',
             '12345678910',
@@ -25,11 +25,11 @@ describe('OMSKorrigering', () => {
         expect(korrigering.fravaersperioder).toEqual([]);
     });
 
-    it('beholder gyldige timerverdier for delvis fravær og trimmer whitespace før serialisering', () => {
+    it('beholder gyldige desimalverdier for delvis fravær og trimmer whitespace før serialisering', () => {
         const korrigering = new OMSKorrigering(
             {
                 ...getValidValues(),
-                DagerMedDelvisFravær: [{ dato: '2026-02-12', timer: ' 5 : 30 ' }],
+                DagerMedDelvisFravær: [{ dato: '2026-02-12', timer: ' 5,5 ' }],
             },
             'soknad-id',
             '12345678910',
@@ -39,7 +39,7 @@ describe('OMSKorrigering', () => {
         expect(korrigering.fravaersperioder).toEqual([
             {
                 periode: { fom: '2026-02-12', tom: '2026-02-12' },
-                faktiskTidPrDag: '5:30',
+                faktiskTidPrDag: '5,5',
             },
         ]);
     });

--- a/src/test/models/types/OMSKorrigering.spec.ts
+++ b/src/test/models/types/OMSKorrigering.spec.ts
@@ -1,0 +1,46 @@
+import { OMSKorrigering } from 'app/models/types/OMSKorrigering';
+import { KorrigeringAvInntektsmeldingFormValues } from 'app/søknader/korrigeringAvInntektsmelding/types/KorrigeringAvInntektsmeldingFormFieldsValues';
+
+const getValidValues = (): KorrigeringAvInntektsmeldingFormValues => ({
+    OpplysningerOmKorrigering: { dato: '2026-02-01', klokkeslett: '10:00' },
+    Virksomhet: '999999999',
+    ArbeidsforholdId: '',
+    Trekkperioder: [{ fom: '', tom: '' }],
+    PerioderMedRefusjonskrav: [{ fom: '', tom: '' }],
+    DagerMedDelvisFravær: [{ dato: '', timer: '' }],
+});
+
+describe('OMSKorrigering', () => {
+    it('omits delvis fravær rows with invalid timer input from autosave payload', () => {
+        const korrigering = new OMSKorrigering(
+            {
+                ...getValidValues(),
+                DagerMedDelvisFravær: [{ dato: '2026-02-12', timer: '.' }],
+            },
+            'soknad-id',
+            '12345678910',
+            ['jp-1'],
+        );
+
+        expect(korrigering.fravaersperioder).toEqual([]);
+    });
+
+    it('keeps valid delvis fravær timer values and trims whitespace before serialization', () => {
+        const korrigering = new OMSKorrigering(
+            {
+                ...getValidValues(),
+                DagerMedDelvisFravær: [{ dato: '2026-02-12', timer: ' 5 : 30 ' }],
+            },
+            'soknad-id',
+            '12345678910',
+            ['jp-1'],
+        );
+
+        expect(korrigering.fravaersperioder).toEqual([
+            {
+                periode: { fom: '2026-02-12', tom: '2026-02-12' },
+                faktiskTidPrDag: '5:30',
+            },
+        ]);
+    });
+});

--- a/src/test/models/types/OMSKorrigering.spec.ts
+++ b/src/test/models/types/OMSKorrigering.spec.ts
@@ -11,6 +11,66 @@ const getValidValues = (): KorrigeringAvInntektsmeldingFormValues => ({
 });
 
 describe('OMSKorrigering', () => {
+    it('tar med senere trekkperioder selv om første rad er tom', () => {
+        const korrigering = new OMSKorrigering(
+            {
+                ...getValidValues(),
+                Trekkperioder: [
+                    { fom: '', tom: '' },
+                    { fom: '2026-02-10', tom: '2026-02-10' },
+                ],
+            },
+            'soknad-id',
+            '12345678910',
+            ['jp-1'],
+        );
+
+        expect(korrigering.fravaersperioder).toContainEqual({
+            periode: { fom: '2026-02-10', tom: '2026-02-10' },
+            faktiskTidPrDag: '0',
+        });
+    });
+
+    it('tar med senere refusjonsperioder selv om første rad er tom', () => {
+        const korrigering = new OMSKorrigering(
+            {
+                ...getValidValues(),
+                PerioderMedRefusjonskrav: [
+                    { fom: '', tom: '' },
+                    { fom: '2026-02-11', tom: '2026-02-11' },
+                ],
+            },
+            'soknad-id',
+            '12345678910',
+            ['jp-1'],
+        );
+
+        expect(korrigering.fravaersperioder).toContainEqual({
+            periode: { fom: '2026-02-11', tom: '2026-02-11' },
+            faktiskTidPrDag: null,
+        });
+    });
+
+    it('tar med senere delvis fravær-rader selv om første rad er tom', () => {
+        const korrigering = new OMSKorrigering(
+            {
+                ...getValidValues(),
+                DagerMedDelvisFravær: [
+                    { dato: '', timer: '' },
+                    { dato: '2026-02-12', timer: '5,5' },
+                ],
+            },
+            'soknad-id',
+            '12345678910',
+            ['jp-1'],
+        );
+
+        expect(korrigering.fravaersperioder).toContainEqual({
+            periode: { fom: '2026-02-12', tom: '2026-02-12' },
+            faktiskTidPrDag: '5,5',
+        });
+    });
+
     it('utelater delvis fravær-rader med ugyldig timerinput fra autosave-payload', () => {
         const korrigering = new OMSKorrigering(
             {

--- a/src/test/models/types/OMSKorrigering.spec.ts
+++ b/src/test/models/types/OMSKorrigering.spec.ts
@@ -11,7 +11,7 @@ const getValidValues = (): KorrigeringAvInntektsmeldingFormValues => ({
 });
 
 describe('OMSKorrigering', () => {
-    it('omits delvis fravær rows with invalid timer input from autosave payload', () => {
+    it('utelater delvis fravær-rader med ugyldig timerinput fra autosave-payload', () => {
         const korrigering = new OMSKorrigering(
             {
                 ...getValidValues(),
@@ -25,7 +25,7 @@ describe('OMSKorrigering', () => {
         expect(korrigering.fravaersperioder).toEqual([]);
     });
 
-    it('keeps valid delvis fravær timer values and trims whitespace before serialization', () => {
+    it('beholder gyldige timerverdier for delvis fravær og trimmer whitespace før serialisering', () => {
         const korrigering = new OMSKorrigering(
             {
                 ...getValidValues(),


### PR DESCRIPTION
### Behov / Bakgrunn

`Korrigering av inntektsmelding` kunne sende `update` med mellomtilstander fra feltet for delvis fravær, for eksempel `.` eller andre ufullstendige tidsverdier.

Dette traff `PUT /api/omsorgspenger-soknad/oppdater` og kunne gi backend-feil som `Ugyldig tid`, fordi frontend serialiserte verdien videre før den hadde et format backend faktisk kan mappe.

Feilen var i praksis mest et mellomtilstandsproblem, men den førte til unødvendig støy i backend-loggene under vanlig utfylling av feltet.

### Løsning

La inn frontend-validering og serialiseringsguard for feltet for delvis fravær i `Korrigering av inntektsmelding`, slik at bare gyldige timerverdier sendes videre i `update`.

Feltet godtar nå timer og desimaltimer i et gyldig format, og ugyldige eller ufullstendige mellomtilstander blir stoppet lokalt i stedet for å bli sendt videre som `faktiskTidPrDag`.

Maksgrensen på `7,5` timer vurderes fortsatt lokalt før videre validering i backend.

### Andre endringer

La til målrettede unit tester for `OMSKorrigering`-payload og for validering av ugyldig tidsformat og grensekontroll i delvis fravær.

Fiksen endrer ikke at `update` trigges under skriving, men sørger for at ugyldig mellominput ikke lenger velter backend eller blir sendt videre som gyldig tid.