### PR TITLE
chore: oppdater CI-baseline til Node 22

### DIFF
--- a/.github/workflows/build-and-deploy-gcp.yml
+++ b/.github/workflows/build-and-deploy-gcp.yml
@@ -54,7 +54,7 @@ jobs:
             - name: Sette opp Node
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: 20.x
+                  node-version: 22.22.3
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@navikt'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Sette opp Node
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: 20.x
+                  node-version: 22.22.3
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@navikt'
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -28,7 +28,7 @@ jobs:
             - name: Sette opp Node
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: 20.x
+                  node-version: 22.22.3
                   registry-url: https://npm.pkg.github.com/
                   scope: '@navikt'
 

--- a/.github/workflows/cypress-tester.yml
+++ b/.github/workflows/cypress-tester.yml
@@ -33,7 +33,7 @@ jobs:
             - name: Sette opp Node
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: 20.x
+                  node-version: 22.22.3
                   registry-url: https://npm.pkg.github.com/
                   scope: '@navikt'
 

--- a/.github/workflows/deploy-preprod-gcp.yml
+++ b/.github/workflows/deploy-preprod-gcp.yml
@@ -39,7 +39,7 @@ jobs:
             - name: Sette opp Node
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: 20.x
+                  node-version: 22.22.3
                   registry-url: https://npm.pkg.github.com/
                   scope: '@navikt'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Sette opp Node
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: 20.x
+                  node-version: 22.22.3
                   registry-url: https://npm.pkg.github.com/
                   scope: '@navikt'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
             - name: Sette opp Node
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: 20.x
+                  node-version: 22.22.3
                   registry-url: https://npm.pkg.github.com/
                   scope: '@navikt'
 

--- a/copilot-tasks/weekly-package-maintenance.md
+++ b/copilot-tasks/weekly-package-maintenance.md
@@ -82,7 +82,7 @@ Suggested starter prompt:
 - Keep `webpack` pinned to `5.107.0` until the PSB country-list regression is resolved. `5.107.2` and `5.108.3` can emit `i18n-iso-countries/codes.json` as an empty payload in production style bundles.
 - For future `webpack` updates, do not rely only on local dev or a successful local build. Verify in Q or another production-like environment that PSB countries are shown for `utenlandsopphold`, and explicitly check that the country dropdown is populated.
 - Avoid forcing transitive major jumps through broad `resolutions`. A previous `uuid@npm:^8.3.2 -> 14.0.1` override looked tidy in `yarn why`, but it overrode `sockjs` onto a different major than requested.
-- Do not attempt `webpack-dev-server@6` inside the normal weekly pass while the repo baseline and CI still target Node `20.x`. Treat that upgrade as a separate task that first decides the repo Node baseline, then rechecks Fast Refresh and the custom dev server startup script.
+- The repo baseline and CI now target Node `22.22.3`, so `webpack-dev-server@6` is no longer blocked by the old Node `20.x` floor. Keep that upgrade as a separate task anyway, and recheck Fast Refresh plus the custom dev server startup script before merging it.
 - Current targeted security overrides that should be revisited in later runs are `form-data@4.0.6`, `http-proxy-middleware@2.0.10`, `undici@6.27.0`, and `@opentelemetry/core@2.8.0`. Remove them once the graph naturally resolves to equal or newer safe versions.
 - Recheck whether a direct bump of `@sentry/cli` can replace the temporary `undici` override after the newer CLI version is outside the 7 day cooldown window.
 - `npm view` for some `@navikt/*` packages can return `401` from the configured registry in this shell.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Kort logg over merkbare repo-endringer og oppsettendringer.
 
+### Node 22 baseline i CI og repo-workflows (2026-08-03)
+
+- Løftet GitHub Actions-workflows fra `node-version: 20.x` til `22.22.3`, slik at CI-baselinen følger repoets valgte Node 22-spor og ikke lenger ligger bak produksjonsruntime på Node 22.
+- Oppdaterte den tilhørende Copilot-tasknoten for package maintenance, siden `webpack-dev-server@6` ikke lenger er blokkert av den gamle Node 20-baselinen i CI. Selve dev-server-løftet holdes fortsatt som en separat oppfølging.
+
 ### Kritiske security overrides for tar og websocket-driver (2026-07-30)
 
 - La inn målrettede `resolutions` for `tar@7.5.21` og `websocket-driver@0.7.5` for å lukke to åpne kritiske advisories i transitive dependencies, uten å dra inn bredere oppgraderinger i build- eller dev-server-stakken.


### PR DESCRIPTION
### Behov / Bakgrunn

Produksjonsruntime bruker allerede Node 22, mens GitHub Actions-workflows fortsatt kjørte på `node-version: 20.x`.

Det ga et unødvendig skille mellom runtime og CI, og holdt igjen videre oppfølging i dev tooling, blant annet vurderingen av `webpack-dev-server@6`.

### Løsning

Oppdaterte alle relevante GitHub Actions-workflows fra `node-version: 20.x` til `22.22.3`.

Dette gjelder workflowene for lint, test, build, Cypress, deploy til preprod, deploy til prod og Copilot setup.

Oppdaterte også repoets package maintenance-notat, siden `webpack-dev-server@6` ikke lenger er blokkert av den gamle Node 20-baselinen i CI.