### PR TITLE
chore: oppdater pinned github actions i workflows

### DIFF
--- a/.github/workflows/build-and-deploy-gcp.yml
+++ b/.github/workflows/build-and-deploy-gcp.yml
@@ -41,7 +41,7 @@ jobs:
             image: ${{ steps.docker-push.outputs.image }}
         steps:
             - name: Hente kode
-              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
             - name: Setup .yarnrc.yml
               run: |
@@ -52,7 +52,7 @@ jobs:
                   NPM_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
 
             - name: Sette opp Node
-              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22.22.3
                   registry-url: 'https://npm.pkg.github.com'
@@ -73,7 +73,7 @@ jobs:
               env:
                   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
-            - uses: nais/docker-build-push@05dbb6091b30bd84279c6d64a45ef8782fd410a5 # v0
+            - uses: nais/docker-build-push@31c3a7321909bcb20799fdf46153fec721fd9512 # v0
               id: docker-push
               with:
                   tag: 'latest'
@@ -91,7 +91,7 @@ jobs:
                   echo "IMAGE=${{steps.docker-push.outputs.image}}" >> $GITHUB_ENV
 
             - name: Deploye til prod gcp
-              uses: nais/deploy/actions/deploy@c55d6073d913975d2dada508bdfefc6427d39867 # v2
+              uses: nais/deploy/actions/deploy@fc3eae3edebabdf67f7592102ae16176d5ba3b5f # v2
               env:
                   CLUSTER: prod-gcp
                   RESOURCE: nais/k9-punsj-frontend.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Hente kode
-              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
             - name: Setup .yarnrc.yml
               run: |
                   yarn config set npmScopes.navikt.npmRegistryServer "https://npm.pkg.github.com"
@@ -23,7 +23,7 @@ jobs:
               env:
                   NPM_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
             - name: Sette opp Node
-              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22.22.3
                   registry-url: 'https://npm.pkg.github.com'
@@ -42,5 +42,5 @@ jobs:
     sif-code-scan:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
             - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@97a944ba12c0db588a29cfeed8a7dcb22e087d3f # v1

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -17,7 +17,7 @@ jobs:
             packages: read
         steps:
             - name: Hente kode
-              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
             - name: Setup .yarnrc.yml
               run: |
@@ -26,7 +26,7 @@ jobs:
                   yarn config set npmScopes.navikt.npmAuthToken ${{ secrets.GITHUB_TOKEN }}
 
             - name: Sette opp Node
-              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22.22.3
                   registry-url: https://npm.pkg.github.com/

--- a/.github/workflows/cypress-tester.yml
+++ b/.github/workflows/cypress-tester.yml
@@ -20,7 +20,7 @@ jobs:
                 ci_total: [4]
         steps:
             - name: Hente kode
-              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
             - name: Setup .yarnrc.yml
               run: |
@@ -31,7 +31,7 @@ jobs:
                   NPM_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
 
             - name: Sette opp Node
-              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22.22.3
                   registry-url: https://npm.pkg.github.com/
@@ -46,7 +46,7 @@ jobs:
               run: npx cypress install
 
             - name: Start E2E-server
-              uses: cypress-io/github-action@948d67d3074f1bbb6379c8bdbb04e95d2f8e593f # v7.4.0
+              uses: cypress-io/github-action@fa4a118725a8f001170d49631ea89e5d66fee626 # v7.4.1
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
               with:

--- a/.github/workflows/deploy-preprod-gcp.yml
+++ b/.github/workflows/deploy-preprod-gcp.yml
@@ -28,7 +28,7 @@ jobs:
         needs: [lint, test, build]
         steps:
             - name: Hente kode
-              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
             - name: Setup .yarnrc.yml
               run: |
                   yarn config set npmScopes.navikt.npmRegistryServer "https://npm.pkg.github.com"
@@ -37,7 +37,7 @@ jobs:
               env:
                   NPM_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
             - name: Sette opp Node
-              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22.22.3
                   registry-url: https://npm.pkg.github.com/
@@ -53,7 +53,7 @@ jobs:
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
 
-            - uses: nais/docker-build-push@05dbb6091b30bd84279c6d64a45ef8782fd410a5 # v0
+            - uses: nais/docker-build-push@31c3a7321909bcb20799fdf46153fec721fd9512 # v0
               id: docker-push
               with:
                   tag: 'latest'
@@ -70,7 +70,7 @@ jobs:
               run: echo "IMAGE=${{steps.docker-push.outputs.image}}" >> $GITHUB_ENV
 
             - name: Deploye til dev
-              uses: nais/deploy/actions/deploy@c55d6073d913975d2dada508bdfefc6427d39867 # v2
+              uses: nais/deploy/actions/deploy@fc3eae3edebabdf67f7592102ae16176d5ba3b5f # v2
               env:
                   CLUSTER: dev-gcp
                   RESOURCE: nais/k9-punsj-frontend.yml

--- a/.github/workflows/deploy-redirect.yml
+++ b/.github/workflows/deploy-redirect.yml
@@ -19,9 +19,9 @@ jobs:
         name: Deploye redirect fra ${{github.event.inputs.environment}}-fss til ${{github.event.inputs.environment}}-gcp
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
             - name: Deploye til dev
-              uses: nais/deploy/actions/deploy@c55d6073d913975d2dada508bdfefc6427d39867 # v2
+              uses: nais/deploy/actions/deploy@fc3eae3edebabdf67f7592102ae16176d5ba3b5f # v2
               env:
                   CLUSTER: ${{ github.event.inputs.environment }}-fss
                   RESOURCE: nais/${{ github.event.inputs.environment }}-fss-redirect.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Hente kode
-              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
             - name: Setup .yarnrc.yml
               run: |
                   yarn config set npmScopes.navikt.npmRegistryServer "https://npm.pkg.github.com"
@@ -23,7 +23,7 @@ jobs:
               env:
                   NPM_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
             - name: Sette opp Node
-              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22.22.3
                   registry-url: https://npm.pkg.github.com/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Hente kode
-              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
             - name: Setup .yarnrc.yml
               run: |
                   yarn config set npmScopes.navikt.npmRegistryServer "https://npm.pkg.github.com"
@@ -24,7 +24,7 @@ jobs:
               env:
                   NPM_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
             - name: Sette opp Node
-              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22.22.3
                   registry-url: https://npm.pkg.github.com/


### PR DESCRIPTION
### Behov / Bakgrunn

Vi hadde en Dependabot oppdatering for GitHub Actions som oppdaterte pinned SHA-er i flere workflows.
I samme endring var versjonskommentarene for `actions/checkout` og `actions/setup-node` misvisende.

### Løsning

Oppdaterte pinned SHA-er for:
- `actions/checkout`
- `actions/setup-node`
- `nais/docker-build-push`
- `nais/deploy/actions/deploy`
- `cypress-io/github-action`

Rettet også versjonskommentarene for `actions/checkout` og `actions/setup-node` slik at de matcher faktisk oppdatert versjon.