### PR TITLE
Flytter token location og gjør yarn config reusable

### DIFF
--- a/.github/actions/configure-yarn/action.yml
+++ b/.github/actions/configure-yarn/action.yml
@@ -1,0 +1,19 @@
+name: "Configure Yarn for GitHub Packages"
+description: "Configures the @navikt scope registry and auth token in the home yarnrc"
+inputs:
+  token:
+    description: "Auth token for npm.pkg.github.com"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Enable Corepack
+      shell: bash
+      run: corepack enable
+
+    - name: Configure Yarn for GitHub Packages
+      shell: bash
+      run: |
+        yarn config set --home npmScopes.navikt.npmRegistryServer "https://npm.pkg.github.com"
+        yarn config set --home npmScopes.navikt.npmAlwaysAuth true
+        yarn config set --home npmScopes.navikt.npmAuthToken "${{ inputs.token }}"

--- a/.github/workflows/build-and-deploy-gcp.yml
+++ b/.github/workflows/build-and-deploy-gcp.yml
@@ -37,17 +37,17 @@ jobs:
             - name: Hente kode
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-            - name: Configure Yarn for GitHub Packages
-              uses: ./.github/actions/configure-yarn
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
-
             - name: Sette opp Node
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22.22.3
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@navikt'
+
+            - name: Configure Yarn for GitHub Packages
+              uses: ./.github/actions/configure-yarn
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
             - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:

--- a/.github/workflows/build-and-deploy-gcp.yml
+++ b/.github/workflows/build-and-deploy-gcp.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
     contents: read
+    packages: read
 
 jobs:
     lint:
@@ -36,6 +37,7 @@ jobs:
         permissions:
             contents: read
             id-token: write
+            packages: read
         needs: [lint, test, test-cypress, build]
         outputs:
             image: ${{ steps.docker-push.outputs.image }}
@@ -43,13 +45,10 @@ jobs:
             - name: Hente kode
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-            - name: Setup .yarnrc.yml
-              run: |
-                  yarn config set npmScopes.navikt.npmRegistryServer "https://npm.pkg.github.com"
-                  yarn config set npmScopes.navikt.npmAlwaysAuth true
-                  yarn config set npmScopes.navikt.npmAuthToken $NPM_AUTH_TOKEN
-              env:
-                  NPM_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+            - name: Configure Yarn for GitHub Packages
+              uses: ./.github/actions/configure-yarn
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Sette opp Node
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/build-and-deploy-gcp.yml
+++ b/.github/workflows/build-and-deploy-gcp.yml
@@ -17,20 +17,12 @@ permissions:
 jobs:
     lint:
         uses: ./.github/workflows/lint.yml
-        secrets:
-            READER_TOKEN: ${{ secrets.READER_TOKEN }}
     test:
         uses: ./.github/workflows/test.yml
-        secrets:
-            READER_TOKEN: ${{ secrets.READER_TOKEN }}
     test-cypress:
         uses: ./.github/workflows/cypress-tester.yml
-        secrets:
-            READER_TOKEN: ${{ secrets.READER_TOKEN }}
     build:
         uses: ./.github/workflows/build.yml
-        secrets:
-            READER_TOKEN: ${{ secrets.READER_TOKEN }}
     deploy:
         name: Deploye til PROD
         runs-on: ubuntu-latest
@@ -65,7 +57,7 @@ jobs:
             - name: Installere moduler
               run: yarn workspaces focus @k9-punsj-frontend/server --production
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Opprett release med Sentry
               run: yarn sentry-release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,6 @@ name: Build
 
 on:
     workflow_call:
-        secrets:
-            READER_TOKEN:
-                required: true
 
 permissions:
     contents: read
@@ -32,7 +29,7 @@ jobs:
             - name: Installere moduler
               run: yarn install --immutable
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Bygge kode
               run: yarn build
             - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,16 +15,16 @@ jobs:
         steps:
             - name: Hente kode
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-            - name: Configure Yarn for GitHub Packages
-              uses: ./.github/actions/configure-yarn
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
             - name: Sette opp Node
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22.22.3
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@navikt'
+            - name: Configure Yarn for GitHub Packages
+              uses: ./.github/actions/configure-yarn
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Installere moduler
               run: yarn install --immutable

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,16 +12,16 @@ permissions:
 jobs:
     build:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: read
         steps:
             - name: Hente kode
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-            - name: Setup .yarnrc.yml
-              run: |
-                  yarn config set npmScopes.navikt.npmRegistryServer "https://npm.pkg.github.com"
-                  yarn config set npmScopes.navikt.npmAlwaysAuth true
-                  yarn config set npmScopes.navikt.npmAuthToken $NPM_AUTH_TOKEN
-              env:
-                  NPM_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+            - name: Configure Yarn for GitHub Packages
+              uses: ./.github/actions/configure-yarn
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
             - name: Sette opp Node
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,17 +19,17 @@ jobs:
             - name: Hente kode
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-            - name: Configure Yarn for GitHub Packages
-              uses: ./.github/actions/configure-yarn
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
-
             - name: Sette opp Node
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22.22.3
                   registry-url: https://npm.pkg.github.com/
                   scope: '@navikt'
+
+            - name: Configure Yarn for GitHub Packages
+              uses: ./.github/actions/configure-yarn
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Installere moduler
               run: yarn install --immutable

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,11 +19,10 @@ jobs:
             - name: Hente kode
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-            - name: Setup .yarnrc.yml
-              run: |
-                  yarn config set npmScopes.navikt.npmRegistryServer "https://npm.pkg.github.com"
-                  yarn config set npmScopes.navikt.npmAlwaysAuth true
-                  yarn config set npmScopes.navikt.npmAuthToken ${{ secrets.GITHUB_TOKEN }}
+            - name: Configure Yarn for GitHub Packages
+              uses: ./.github/actions/configure-yarn
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Sette opp Node
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/cypress-tester.yml
+++ b/.github/workflows/cypress-tester.yml
@@ -2,9 +2,6 @@ name: Cypress-tester
 
 on:
     workflow_call:
-        secrets:
-            READER_TOKEN:
-                required: true
 
 permissions:
     contents: read
@@ -40,7 +37,7 @@ jobs:
             - name: Installere moduler
               run: yarn install --immutable
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Installere Cypress
               run: npx cypress install
@@ -48,7 +45,7 @@ jobs:
             - name: Start E2E-server
               uses: cypress-io/github-action@fa4a118725a8f001170d49631ea89e5d66fee626 # v7.4.1
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   start: yarn start:e2e
                   wait-on: 'http://localhost:8080'

--- a/.github/workflows/cypress-tester.yml
+++ b/.github/workflows/cypress-tester.yml
@@ -22,17 +22,17 @@ jobs:
             - name: Hente kode
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-            - name: Configure Yarn for GitHub Packages
-              uses: ./.github/actions/configure-yarn
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
-
             - name: Sette opp Node
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22.22.3
                   registry-url: https://npm.pkg.github.com/
                   scope: '@navikt'
+
+            - name: Configure Yarn for GitHub Packages
+              uses: ./.github/actions/configure-yarn
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Installere moduler
               run: yarn install --immutable

--- a/.github/workflows/cypress-tester.yml
+++ b/.github/workflows/cypress-tester.yml
@@ -13,6 +13,9 @@ jobs:
     test:
         name: Cypress-tester
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: read
         strategy:
             fail-fast: false
             matrix:
@@ -22,13 +25,10 @@ jobs:
             - name: Hente kode
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-            - name: Setup .yarnrc.yml
-              run: |
-                  yarn config set npmScopes.navikt.npmRegistryServer "https://npm.pkg.github.com"
-                  yarn config set npmScopes.navikt.npmAlwaysAuth true
-                  yarn config set npmScopes.navikt.npmAuthToken $NPM_AUTH_TOKEN
-              env:
-                  NPM_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+            - name: Configure Yarn for GitHub Packages
+              uses: ./.github/actions/configure-yarn
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Sette opp Node
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/deploy-preprod-gcp.yml
+++ b/.github/workflows/deploy-preprod-gcp.yml
@@ -9,16 +9,10 @@ permissions:
 jobs:
     lint:
         uses: ./.github/workflows/lint.yml
-        secrets:
-            READER_TOKEN: ${{ secrets.READER_TOKEN }}
     test:
         uses: ./.github/workflows/test.yml
-        secrets:
-            READER_TOKEN: ${{ secrets.READER_TOKEN }}
     build:
         uses: ./.github/workflows/build.yml
-        secrets:
-            READER_TOKEN: ${{ secrets.READER_TOKEN }}
     deploy-dev-gcp:
         name: Deploye til DEV GCP
         runs-on: ubuntu-latest
@@ -49,7 +43,7 @@ jobs:
             - name: Installere moduler
               run: yarn workspaces focus @k9-punsj-frontend/server --production
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - uses: nais/docker-build-push@31c3a7321909bcb20799fdf46153fec721fd9512 # v0
               id: docker-push

--- a/.github/workflows/deploy-preprod-gcp.yml
+++ b/.github/workflows/deploy-preprod-gcp.yml
@@ -4,6 +4,7 @@ on:
 
 permissions:
     contents: read
+    packages: read
 
 jobs:
     lint:
@@ -29,13 +30,10 @@ jobs:
         steps:
             - name: Hente kode
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-            - name: Setup .yarnrc.yml
-              run: |
-                  yarn config set npmScopes.navikt.npmRegistryServer "https://npm.pkg.github.com"
-                  yarn config set npmScopes.navikt.npmAlwaysAuth true
-                  yarn config set npmScopes.navikt.npmAuthToken $NPM_AUTH_TOKEN
-              env:
-                  NPM_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+            - name: Configure Yarn for GitHub Packages
+              uses: ./.github/actions/configure-yarn
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
             - name: Sette opp Node
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:

--- a/.github/workflows/deploy-preprod-gcp.yml
+++ b/.github/workflows/deploy-preprod-gcp.yml
@@ -24,16 +24,16 @@ jobs:
         steps:
             - name: Hente kode
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-            - name: Configure Yarn for GitHub Packages
-              uses: ./.github/actions/configure-yarn
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
             - name: Sette opp Node
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22.22.3
                   registry-url: https://npm.pkg.github.com/
                   scope: '@navikt'
+            - name: Configure Yarn for GitHub Packages
+              uses: ./.github/actions/configure-yarn
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
             - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,6 @@ name: Lint
 
 on:
     workflow_call:
-        secrets:
-            READER_TOKEN:
-                required: true
 
 permissions:
     contents: read
@@ -32,6 +29,6 @@ jobs:
             - name: Installere moduler
               run: yarn install --immutable
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Sjekke opp mot Lint-regler
               run: yarn run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,16 +15,16 @@ jobs:
         steps:
             - name: Hente kode
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-            - name: Configure Yarn for GitHub Packages
-              uses: ./.github/actions/configure-yarn
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
             - name: Sette opp Node
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22.22.3
                   registry-url: https://npm.pkg.github.com/
                   scope: '@navikt'
+            - name: Configure Yarn for GitHub Packages
+              uses: ./.github/actions/configure-yarn
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Installere moduler
               run: yarn install --immutable

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,16 +12,16 @@ permissions:
 jobs:
     lint:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: read
         steps:
             - name: Hente kode
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-            - name: Setup .yarnrc.yml
-              run: |
-                  yarn config set npmScopes.navikt.npmRegistryServer "https://npm.pkg.github.com"
-                  yarn config set npmScopes.navikt.npmAlwaysAuth true
-                  yarn config set npmScopes.navikt.npmAuthToken $NPM_AUTH_TOKEN
-              env:
-                  NPM_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+            - name: Configure Yarn for GitHub Packages
+              uses: ./.github/actions/configure-yarn
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
             - name: Sette opp Node
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,6 @@ name: Test
 
 on:
     workflow_call:
-        secrets:
-            READER_TOKEN:
-                required: true
 
 permissions:
     contents: read
@@ -33,6 +30,6 @@ jobs:
             - name: Installere moduler
               run: yarn install --immutable
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Kjøre tester
               run: yarn test --maxWorkers=2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,16 +13,16 @@ jobs:
     test:
         name: Tester
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: read
         steps:
             - name: Hente kode
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-            - name: Setup .yarnrc.yml
-              run: |
-                  yarn config set npmScopes.navikt.npmRegistryServer "https://npm.pkg.github.com"
-                  yarn config set npmScopes.navikt.npmAlwaysAuth true
-                  yarn config set npmScopes.navikt.npmAuthToken $NPM_AUTH_TOKEN
-              env:
-                  NPM_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+            - name: Configure Yarn for GitHub Packages
+              uses: ./.github/actions/configure-yarn
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
             - name: Sette opp Node
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,16 +16,16 @@ jobs:
         steps:
             - name: Hente kode
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-            - name: Configure Yarn for GitHub Packages
-              uses: ./.github/actions/configure-yarn
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
             - name: Sette opp Node
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22.22.3
                   registry-url: https://npm.pkg.github.com/
                   scope: '@navikt'
+            - name: Configure Yarn for GitHub Packages
+              uses: ./.github/actions/configure-yarn
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Installere moduler
               run: yarn install --immutable

--- a/.github/workflows/valid-pull-request.yml
+++ b/.github/workflows/valid-pull-request.yml
@@ -5,23 +5,16 @@ on:
 
 permissions:
     contents: read
+    packages: read
 
 jobs:
     lint:
         uses: ./.github/workflows/lint.yml
-        secrets:
-            READER_TOKEN: ${{ secrets.READER_TOKEN }}
 
     test:
         uses: ./.github/workflows/test.yml
-        secrets:
-            READER_TOKEN: ${{ secrets.READER_TOKEN }}
 
     test-cypress:
         uses: ./.github/workflows/cypress-tester.yml
-        secrets:
-            READER_TOKEN: ${{ secrets.READER_TOKEN }}
     build:
         uses: ./.github/workflows/build.yml
-        secrets:
-            READER_TOKEN: ${{ secrets.READER_TOKEN }}


### PR DESCRIPTION
Behov / Bakgrunn

Observert i andre repoer at å sette token i repoets yarnrc kan føre til at copilot comitter actions-tokenet
Løsning

Sette det i home i stedet
Andre endringer

Lager en action av setup